### PR TITLE
Start coding recording during interview initialization

### DIFF
--- a/app/(features)/interview/components/InterviewRecordingContext.tsx
+++ b/app/(features)/interview/components/InterviewRecordingContext.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React, { createContext, useContext, ReactNode } from "react";
+
+/**
+ * Supplies shared recording controls so the coding IDE can reuse the session
+ * created during the interview start flow without re-requesting permissions.
+ */
+export type InterviewRecordingContextValue = {
+    isRecording: boolean;
+    recordingPermissionGranted: boolean;
+    micPermissionGranted: boolean;
+    recordingUrl: string | null;
+    recordingUploaded: boolean;
+    interviewSessionId: string | null;
+    setInterviewSessionId: (sessionId: string | null) => void;
+    startRecording: () => Promise<boolean>;
+    stopRecording: () => Promise<void>;
+    insertRecordingUrl: () => Promise<void>;
+    requestRecordingPermission: () => Promise<boolean>;
+    setRecordingPermissionGranted: (granted: boolean) => void;
+    setMicPermissionGranted: (granted: boolean) => void;
+    setRecordingUploaded: (uploaded: boolean) => void;
+    mediaRecorderRef: React.MutableRefObject<MediaRecorder | null>;
+    getActualRecordingStartTime: () => Date | null;
+};
+
+const InterviewRecordingContext =
+    createContext<InterviewRecordingContextValue | null>(null);
+
+/**
+ * Provides shared recording state to interview children.
+ */
+export const InterviewRecordingProvider = ({
+    value,
+    children,
+}: {
+    value: InterviewRecordingContextValue;
+    children: ReactNode;
+}) => {
+    return (
+        <InterviewRecordingContext.Provider value={value}>
+            {children}
+        </InterviewRecordingContext.Provider>
+    );
+};
+
+/**
+ * Returns the shared recording state or throws if the provider is missing.
+ */
+export const useInterviewRecording = () => {
+    const context = useContext(InterviewRecordingContext);
+    if (!context) {
+        throw new Error(
+            "useInterviewRecording must be used within an InterviewRecordingProvider"
+        );
+    }
+
+    return context;
+};


### PR DESCRIPTION
## Summary
- start screen recording and create the coding session during the initial interview start flow so the IDE reuses it
- share the recording/session state via a dedicated context and pass it into the coding stage render
- guard the coding launch handler to avoid duplicate prompts and log the reused recording start time

## Testing
- pnpm lint *(fails: ESLint must be installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b9c5b714832b81c607fccacd1a44)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Begin screen recording and create the coding session during interview initialization, sharing recording/session state via a new context used by the IDE.
> 
> - **Interview flow**:
>   - Initialize screen recording during start flow and create coding `interviewSession` with `recordingStartedAt`; store `sessionId` in Redux and preload/create `applicationId` if missing.
>   - Add guards for missing/duplicate recording prompts and reuse the recording start time.
> - **Context**:
>   - Introduce `InterviewRecordingContext` (`InterviewRecordingProvider`, `useInterviewRecording`) to share recording/session controls (`mediaRecorderRef`, permission flags, `start/stop`, `insertRecordingUrl`, `getActualRecordingStartTime`, `interviewSessionId`).
> - **IDE (`components/InterviewIDE.tsx`)**:
>   - Switch from `useScreenRecording` to `useInterviewRecording` and require existing `interviewSessionId` before starting.
>   - Simplify start handler to reuse shared recording and clear chat; remove inline application/session creation logic.
> - **Page (`interview/page.tsx`)**:
>   - Wire `useScreenRecording`, `ensureRecordingSession`, and `resolveApplicationId`; create session via `createInterviewSession` and dispatch `setSessionId`/`setPreloadedData`.
>   - Wrap `InterviewIDE` with `InterviewRecordingProvider`; reset `interviewSessionId` on full reset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58a44195d8ab8aeeb972f09d790ed3b3d277acd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->