### PR TITLE
Add shared coding stage transition helper

### DIFF
--- a/app/(features)/background-interview/page.tsx
+++ b/app/(features)/background-interview/page.tsx
@@ -37,6 +37,7 @@ import { shouldTransition } from "@/shared/services/backgroundSessionGuard";
 import { createInterviewSession } from "../interview/components/services/interviewSessionService";
 import { buildControlContextMessages, CONTROL_CONTEXT_TURNS } from "../../shared/services";
 import { loadAndCacheSoundEffect } from "@/shared/utils/audioCache";
+import { startCodingStage } from "@/shared/services/codingStageTransition";
 
 export default function BackgroundInterviewPage() {
   const router = useRouter();
@@ -48,6 +49,12 @@ export default function BackgroundInterviewPage() {
   );
   const companyName = useSelector(
     (state: RootState) => state.interviewMachine.companyName
+  );
+  const companySlug = useSelector(
+    (state: RootState) => state.interviewMachine.companySlug
+  );
+  const roleSlug = useSelector(
+    (state: RootState) => state.interviewMachine.roleSlug
   );
   const preloadedFirstQuestion = useSelector(
     (state: RootState) => state.interviewMachine.preloadedFirstQuestion
@@ -88,6 +95,7 @@ export default function BackgroundInterviewPage() {
   const [backgroundTimeSeconds, setBackgroundTimeSeconds] = useState<number | undefined>(undefined);
   const [openaiClient, setOpenaiClient] = useState<OpenAI | null>(null);
   const [showDebugPanel, setShowDebugPanel] = useState(false);
+  const [, setShowCodingIDE] = useState(false);
   const [micStream, setMicStream] = useState<MediaStream | null>(null);
   const [allowQuestionDisplay, setAllowQuestionDisplay] = useState(false);
   const [soundsReady, setSoundsReady] = useState(false);
@@ -653,6 +661,14 @@ export default function BackgroundInterviewPage() {
     }
   };
 
+  const handleStartCoding = useCallback(() => {
+    startCodingStage(
+      dispatch,
+      { companyName, companySlug, roleSlug },
+      setShowCodingIDE,
+    );
+  }, [dispatch, companyName, companySlug, roleSlug]);
+
   // STAGE 1: Loading
   if (isPageLoading) {
     return (
@@ -745,7 +761,7 @@ export default function BackgroundInterviewPage() {
         <div className="flex-1 flex items-center justify-center p-4">
           <CompletionScreen
             codingTimeChallenge={codingTimeChallenge}
-            onStartCoding={() => {}}
+            onStartCoding={handleStartCoding}
           />
         </div>
 

--- a/app/(features)/interview/page.tsx
+++ b/app/(features)/interview/page.tsx
@@ -11,7 +11,6 @@ import {
   aiFinal,
   reset,
   setPageLoading,
-  forceCoding,
   setCompanyContext,
   setSessionId,
   setPreloadedData,
@@ -27,6 +26,7 @@ import { useScreenRecording } from "./components/hooks/useScreenRecording";
 import { InterviewRecordingProvider } from "./components/InterviewRecordingContext";
 import { createInterviewSession } from "./components/services/interviewSessionService";
 import { createApplication } from "./components/services/applicationService";
+import { startCodingStage } from "@/shared/services/codingStageTransition";
 import OpenAI from "openai";
 import {
   useBackgroundPreload,
@@ -383,15 +383,11 @@ function InterviewPageContent() {
 
   // Start coding handler
   const handleStartCoding = () => {
-    // Dispatch company context (already in Redux from preload, but ensure it's set)
-    dispatch(setCompanyContext({
-      companyName: companyName || (companySlug ? companySlug.charAt(0).toUpperCase() + companySlug.slice(1) : "Meta"),
-      companySlug: companySlug || "meta",
-      roleSlug: roleSlug || "frontend-engineer",
-    }));
-    dispatch(forceCoding());
-    interviewChatStore.dispatch({ type: "SET_STAGE", payload: "coding" } as any);
-    setShowCodingIDE(true);
+    startCodingStage(
+      dispatch,
+      { companyName, companySlug, roleSlug },
+      setShowCodingIDE,
+    );
   };
 
   // ===== RENDER CONDITIONS =====

--- a/shared/services/codingStageTransition.ts
+++ b/shared/services/codingStageTransition.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers for moving interview flows into the coding stage.
+ */
+import { interviewChatStore } from "@/shared/state/interviewChatStore";
+import { AppDispatch } from "@/shared/state/store";
+import { forceCoding, setCompanyContext } from "@/shared/state/slices/interviewMachineSlice";
+
+/**
+ * Dispatches the necessary state updates to enter the coding experience.
+ */
+export const startCodingStage = (
+  dispatch: AppDispatch,
+  context: {
+    companyName?: string | null;
+    companySlug?: string | null;
+    roleSlug?: string | null;
+  },
+  setShowCodingIDE: (show: boolean) => void,
+) => {
+  const resolvedCompanyName =
+    context.companyName ||
+    (context.companySlug
+      ? `${context.companySlug.charAt(0).toUpperCase()}${context.companySlug.slice(1)}`
+      : "Meta");
+
+  dispatch(
+    setCompanyContext({
+      companyName: resolvedCompanyName,
+      companySlug: context.companySlug || "meta",
+      roleSlug: context.roleSlug || "frontend-engineer",
+    })
+  );
+  dispatch(forceCoding());
+  interviewChatStore.dispatch({ type: "SET_STAGE", payload: "coding" } as any);
+  setShowCodingIDE(true);
+};


### PR DESCRIPTION
## Summary
- add a shared helper to transition interview flows into the coding stage
- reuse the helper for the interview and background interview completion screens
- ensure the background completion screen triggers the coding stage start callback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c0637c44832bb91a0b1533ca96fd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `startCodingStage` shared helper and updates interview/background interview pages to use it, wiring completion screens to start coding.
> 
> - **Shared service**:
>   - Add `shared/services/codingStageTransition.ts` with `startCodingStage` to set `company` context, dispatch `forceCoding`, update `interviewChatStore` stage, and show IDE.
> - **Interview flows**:
>   - `app/(features)/interview/page.tsx`: replace inline coding-start logic with `startCodingStage`; remove direct `forceCoding` usage.
>   - `app/(features)/background-interview/page.tsx`: select `companySlug`/`roleSlug`, add `handleStartCoding` using `startCodingStage`, and pass it to `CompletionScreen` via `onStartCoding`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 501dfdb2506cd10c06efa1347be7ec580f6f2550. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->