### PR TITLE
Add category-based logging and require category on all log calls

### DIFF
--- a/app/(features)/company-dashboard/applicants/[jobId]/page.tsx
+++ b/app/(features)/company-dashboard/applicants/[jobId]/page.tsx
@@ -9,6 +9,8 @@ import Breadcrumbs from "app/shared/components/Breadcrumbs";
 import { log } from "app/shared/services";
 import { getBreadcrumbTrail } from "app/shared/config/navigation";
 
+const LOG_CATEGORY = "company-dashboard";
+
 interface Applicant {
   id: string;
   name: string;
@@ -51,7 +53,7 @@ function JobApplicantsContent() {
         setData(result);
         setError(null);
       } catch (err) {
-        log.error("Failed to fetch applicants:", err);
+        log.error(LOG_CATEGORY, "Failed to fetch applicants:", err);
         setError(err instanceof Error ? err.message : "Unknown error");
       } finally {
         setLoading(false);

--- a/app/(features)/company-dashboard/content.tsx
+++ b/app/(features)/company-dashboard/content.tsx
@@ -9,6 +9,8 @@ import { log } from "app/shared/services";
 import { readResponseError } from "app/shared/utils/http";
 import { SfinxSpinner } from "app/shared/components";
 import InterviewContentSection, {
+
+const LOG_CATEGORY = "company-dashboard";
     InterviewContentState,
     InterviewDurationState,
     defaultInterviewDurations,
@@ -68,7 +70,7 @@ function CompanyDashboardContent() {
 
     useEffect(() => {
         const fetchJobs = async () => {
-            log.info("Fetching company jobs...");
+            log.info(LOG_CATEGORY, "Fetching company jobs...");
             try {
                 const resp = await fetch("/api/company/jobs");
                 if (!resp.ok) {
@@ -108,14 +110,14 @@ function CompanyDashboardContent() {
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : "Unknown error";
-                log.error("❌ Failed to fetch company jobs:", err);
+                log.error(LOG_CATEGORY, "❌ Failed to fetch company jobs:", err);
                 setError(message);
             } finally {
                 setLoading(false);
             }
         };
         fetchJobs().catch((err) => {
-            log.error("❌ Unexpected fetch error:", err);
+            log.error(LOG_CATEGORY, "❌ Unexpected fetch error:", err);
         });
     }, []);
 
@@ -214,7 +216,7 @@ function CompanyDashboardContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to create job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to create job:", err);
         } finally {
             setCreateSubmitting(false);
         }
@@ -237,7 +239,7 @@ function CompanyDashboardContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to delete job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to delete job:", err);
         } finally {
             setDeleteInFlight(null);
         }

--- a/app/(features)/company-dashboard/jobs/[jobId]/page.tsx
+++ b/app/(features)/company-dashboard/jobs/[jobId]/page.tsx
@@ -10,6 +10,8 @@ import { log } from "app/shared/services";
 import { readResponseError } from "app/shared/utils/http";
 import { getBreadcrumbTrail } from "app/shared/config/navigation";
 import InterviewContentSection, {
+
+const LOG_CATEGORY = "company-dashboard";
     InterviewContentState,
     InterviewDurationState,
     defaultInterviewDurations,
@@ -176,13 +178,13 @@ function CompanyJobDetailContent() {
                 const message =
                     err instanceof Error ? err.message : "Unknown error";
                 setError(message);
-                log.error("❌ Failed to load company job detail:", err);
+                log.error(LOG_CATEGORY, "❌ Failed to load company job detail:", err);
             } finally {
                 setLoading(false);
             }
         };
         fetchDetail().catch((err) => {
-            log.error("❌ Unexpected job detail fetch error:", err);
+            log.error(LOG_CATEGORY, "❌ Unexpected job detail fetch error:", err);
         });
     }, [jobId]);
 
@@ -197,7 +199,7 @@ function CompanyJobDetailContent() {
                     }
                 }
             } catch (err) {
-                log.error("❌ Failed to load scoring configuration:", err);
+                log.error(LOG_CATEGORY, "❌ Failed to load scoring configuration:", err);
             }
         };
         fetchScoringConfig();
@@ -320,7 +322,7 @@ function CompanyJobDetailContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to save company job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to save company job:", err);
         } finally {
             setSaving(false);
         }
@@ -351,7 +353,7 @@ function CompanyJobDetailContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to remove interview content:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to remove interview content:", err);
         } finally {
             setRemovingInterview(false);
         }

--- a/app/(features)/company-dashboard/jobs/new/page.tsx
+++ b/app/(features)/company-dashboard/jobs/new/page.tsx
@@ -7,6 +7,8 @@ import { AuthGuard } from "app/shared/components";
 import { log } from "app/shared/services";
 import { readResponseError } from "app/shared/utils/http";
 import InterviewContentSection, {
+
+const LOG_CATEGORY = "company-dashboard";
     InterviewContentState,
     InterviewDurationState,
     defaultInterviewDurations,
@@ -135,13 +137,13 @@ function CreateJobContent() {
                 );
             }
             
-            log.info("Job created successfully");
+            log.info(LOG_CATEGORY, "Job created successfully");
             router.push("/company-dashboard/jobs");
         } catch (err) {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to create job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to create job:", err);
         } finally {
             setCreateSubmitting(false);
         }

--- a/app/(features)/company-dashboard/jobs/page.tsx
+++ b/app/(features)/company-dashboard/jobs/page.tsx
@@ -11,6 +11,8 @@ import { JobGrid, JobGridJob } from "app/shared/components/jobs/JobGrid";
 import type { JobGridCompany } from "app/shared/components/jobs/JobGrid";
 import { readResponseError } from "app/shared/utils/http";
 import InterviewContentSection, {
+
+const LOG_CATEGORY = "company-dashboard";
     InterviewContentState,
     InterviewDurationState,
     defaultInterviewDurations,
@@ -82,7 +84,7 @@ function CompanyJobsContent() {
 
     useEffect(() => {
         const fetchJobs = async () => {
-            log.info("Fetching company jobs...");
+            log.info(LOG_CATEGORY, "Fetching company jobs...");
             try {
                 const resp = await fetch("/api/company/jobs");
                 if (!resp.ok) {
@@ -122,14 +124,14 @@ function CompanyJobsContent() {
             } catch (err) {
                 const message =
                     err instanceof Error ? err.message : "Unknown error";
-                log.error("❌ Failed to fetch company jobs:", err);
+                log.error(LOG_CATEGORY, "❌ Failed to fetch company jobs:", err);
                 setError(message);
             } finally {
                 setLoading(false);
             }
         };
         fetchJobs().catch((err) => {
-            log.error("❌ Unexpected fetch error:", err);
+            log.error(LOG_CATEGORY, "❌ Unexpected fetch error:", err);
         });
     }, []);
 
@@ -228,7 +230,7 @@ function CompanyJobsContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to create job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to create job:", err);
         } finally {
             setCreateSubmitting(false);
         }
@@ -251,7 +253,7 @@ function CompanyJobsContent() {
             const message =
                 err instanceof Error ? err.message : "Unknown error";
             setError(message);
-            log.error("❌ Failed to delete job:", err);
+            log.error(LOG_CATEGORY, "❌ Failed to delete job:", err);
         } finally {
             setDeleteInFlight(null);
         }

--- a/app/(features)/company-dashboard/settings/page.tsx
+++ b/app/(features)/company-dashboard/settings/page.tsx
@@ -8,6 +8,8 @@ import AuthGuard from "app/shared/components/AuthGuard";
 import Header from "app/shared/components/Header";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "company-dashboard";
+
 export default function CompanySettingsPage() {
     const { data: session, update } = useSession();
     const [uploading, setUploading] = useState(false);
@@ -46,16 +48,16 @@ export default function CompanySettingsPage() {
 
             if (response.ok) {
                 const data = await response.json();
-                log.info("Upload successful, new image URL:", data.imageUrl);
-                log.info("Updating session with new image...");
+                log.info(LOG_CATEGORY, "Upload successful, new image URL:", data.imageUrl);
+                log.info(LOG_CATEGORY, "Updating session with new image...");
 
                 // Update session with new image
-                log.info("Updating session with new image URL...");
+                log.info(LOG_CATEGORY, "Updating session with new image URL...");
                 await update({ image: data.imageUrl });
-                log.info("Session updated with image:", data.imageUrl);
+                log.info(LOG_CATEGORY, "Session updated with image:", data.imageUrl);
 
                 setMessage("Profile image updated successfully!");
-                log.info("Session updated! Avatar should refresh automatically");
+                log.info(LOG_CATEGORY, "Session updated! Avatar should refresh automatically");
             } else {
                 setMessage("Failed to upload image. Please try again.");
             }

--- a/app/(features)/cps/page.tsx
+++ b/app/(features)/cps/page.tsx
@@ -23,6 +23,8 @@ import { calculateScore, type ScoringConfiguration, type RawScores, type Worksty
 import { useDebug } from "app/shared/contexts";
 import { getBreadcrumbTrail } from "app/shared/config/navigation";
 
+const LOG_CATEGORY = "cps";
+
 function TelemetryContent() {
     const searchParams = useSearchParams();
     const router = useRouter();
@@ -120,7 +122,7 @@ function TelemetryContent() {
                     setTelemetryData(null);
                 }
             } catch (error) {
-                log.error("Error fetching telemetry:", error);
+                log.error(LOG_CATEGORY, "Error fetching telemetry:", error);
                 setError("Failed to load telemetry data");
                 setTelemetryData(null);
             } finally {
@@ -156,7 +158,7 @@ function TelemetryContent() {
                     setBackgroundSummary(null);
                 }
             } catch (error) {
-                log.error("Error fetching background summary:", error);
+                log.error(LOG_CATEGORY, "Error fetching background summary:", error);
                 setBackgroundSummary(null);
             } finally {
                 setSummaryLoading(false);
@@ -188,7 +190,7 @@ function TelemetryContent() {
                     setCodingSummary(null);
                 }
             } catch (error) {
-                log.error("Error fetching coding summary:", error);
+                log.error(LOG_CATEGORY, "Error fetching coding summary:", error);
                 setCodingSummary(null);
             } finally {
                 setCodingSummaryLoading(false);
@@ -218,7 +220,7 @@ function TelemetryContent() {
                     }
                 }
             } catch (error) {
-                log.error("Error fetching scoring configuration:", error);
+                log.error(LOG_CATEGORY, "Error fetching scoring configuration:", error);
                 setScoringConfig(null);
             }
         };
@@ -288,7 +290,7 @@ function TelemetryContent() {
             setCalculatedExperienceScore(result.experienceScore);
             setCalculatedCodingScore(result.codingScore);
         } catch (error) {
-            log.error("Error calculating score:", error);
+            log.error(LOG_CATEGORY, "Error calculating score:", error);
             setCalculatedScore(null);
             setCalculatedExperienceScore(null);
             setCalculatedCodingScore(null);

--- a/app/(features)/interview/components/editor/EditorPanel.tsx
+++ b/app/(features)/interview/components/editor/EditorPanel.tsx
@@ -5,6 +5,8 @@ import Editor, { DiffEditor } from "@monaco-editor/react";
 import { Play, RotateCcw } from "lucide-react";
 import CodePreview from "./CodePreview";
 import { log } from "../../../../shared/services";
+
+const LOG_CATEGORY = "interview-ui";
 function computeDiffSegments(
     oldText: string,
     newText: string
@@ -174,11 +176,11 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                         
                         // Store decoration IDs
                         pasteDecorationsRef.current.push(...newDecorations);
-                        log.info("✅ Pasted code highlighted in editor");
+                        log.info(LOG_CATEGORY, "✅ Pasted code highlighted in editor");
                     }
                 }
             } catch (error) {
-                log.error("Failed to highlight pasted code:", error);
+                log.error(LOG_CATEGORY, "Failed to highlight pasted code:", error);
             }
         }
     }, []);
@@ -192,7 +194,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                 editor.deltaDecorations(pasteDecorationsRef.current, []);
                 pasteDecorationsRef.current = [];
             } catch (error) {
-                log.error("Failed to clear paste highlights:", error);
+                log.error(LOG_CATEGORY, "Failed to clear paste highlights:", error);
             }
         }
     }, []);
@@ -255,7 +257,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
             if (pastedText.length >= 80) {
                 const now = Date.now();
                 
-                log.info(
+                log.info(LOG_CATEGORY, 
                     "🚨 Paste detected via native event - external tool usage",
                     { pastedLength: pastedText.length, timestamp: now }
                 );

--- a/app/(features)/job-search/page.tsx
+++ b/app/(features)/job-search/page.tsx
@@ -6,6 +6,8 @@ import { AuthGuard, SfinxSpinner } from "app/shared/components";
 import { log } from "app/shared/services";
 import { JobGrid, JobGridJob } from "app/shared/components/jobs/JobGrid";
 
+const LOG_CATEGORY = "job-search";
+
 interface Job {
     id: string;
     title: string;
@@ -62,7 +64,7 @@ function JobSearchContent() {
     useEffect(() => {
         if (!hydrated) return;
         const fetchCompanies = async () => {
-            log.info("Starting to fetch companies...");
+            log.info(LOG_CATEGORY, "Starting to fetch companies...");
             try {
                 setLoading(true);
                 const params = new URLSearchParams();
@@ -71,14 +73,14 @@ function JobSearchContent() {
                 if (searchCompany) params.append("company", searchCompany);
 
                 const url = `/api/companies?${params.toString()}`;
-                log.info("Fetching from:", url);
+                log.info(LOG_CATEGORY, "Fetching from:", url);
 
                 const response = await fetch(url);
-                log.info("Response status:", response.status);
+                log.info(LOG_CATEGORY, "Response status:", response.status);
 
                 if (response.ok) {
                     const data = await response.json();
-                    log.info("Data received:", data);
+                    log.info(LOG_CATEGORY, "Data received:", data);
                     setCompanies(data.companies);
                     if (!Array.isArray(data.appliedJobIds)) {
                         throw new Error("appliedJobIds missing from response");
@@ -86,20 +88,20 @@ function JobSearchContent() {
                     setAppliedJobIds(data.appliedJobIds);
                     setError(null);
                 } else {
-                    log.error("❌ Response not ok:", response.status, response.statusText);
+                    log.error(LOG_CATEGORY, "❌ Response not ok:", response.status, response.statusText);
                     const errorText = await response.text();
-                    log.error("❌ Error response:", errorText);
+                    log.error(LOG_CATEGORY, "❌ Error response:", errorText);
                     setError(
                         `Failed to load companies: ${response.status} ${response.statusText}`
                     );
                 }
             } catch (error) {
-                log.error("Error fetching companies:", error);
+                log.error(LOG_CATEGORY, "Error fetching companies:", error);
                 setError(
                     "Failed to load companies. Please check your connection and try again."
                 );
             } finally {
-                log.info("Setting loading to false");
+                log.info(LOG_CATEGORY, "Setting loading to false");
                 setLoading(false);
             }
         };

--- a/app/(features)/settings/page.tsx
+++ b/app/(features)/settings/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import AuthGuard from "app/shared/components/AuthGuard";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "settings";
+
 export default function SettingsPage() {
     const { data: session, update } = useSession();
     const [uploading, setUploading] = useState(false);
@@ -16,12 +18,12 @@ export default function SettingsPage() {
         event: React.ChangeEvent<HTMLInputElement>
     ) => {
         const file = event.target.files?.[0];
-        log.info("Selected file:", file);
-        log.info("File name:", file?.name);
-        log.info("File size:", file?.size);
-        log.info("File type:", file?.type);
+        log.info(LOG_CATEGORY, "Selected file:", file);
+        log.info(LOG_CATEGORY, "File name:", file?.name);
+        log.info(LOG_CATEGORY, "File size:", file?.size);
+        log.info(LOG_CATEGORY, "File type:", file?.type);
         if (!file) {
-            log.warn("No file selected");
+            log.warn(LOG_CATEGORY, "No file selected");
             return;
         }
 
@@ -44,32 +46,32 @@ export default function SettingsPage() {
             const formData = new FormData();
             formData.append("image", file);
 
-            log.info("Sending request to /api/upload/profile-image");
+            log.info(LOG_CATEGORY, "Sending request to /api/upload/profile-image");
             const response = await fetch("/api/upload/profile-image", {
                 method: "POST",
                 body: formData,
             });
-            log.info("Response status:", response.status);
-            log.info("Response ok:", response.ok);
+            log.info(LOG_CATEGORY, "Response status:", response.status);
+            log.info(LOG_CATEGORY, "Response ok:", response.ok);
 
             if (response.ok) {
                 const data = await response.json();
-                log.info("Upload successful, new image URL:", data.imageUrl);
-                log.info("Updating session with new image...");
+                log.info(LOG_CATEGORY, "Upload successful, new image URL:", data.imageUrl);
+                log.info(LOG_CATEGORY, "Updating session with new image...");
 
                 // Update session with new image
-                log.info("Updating session with new image URL...");
-                log.info("Current session before update:", session);
+                log.info(LOG_CATEGORY, "Updating session with new image URL...");
+                log.info(LOG_CATEGORY, "Current session before update:", session);
                 await update({ image: data.imageUrl });
-                log.info("Session updated with image:", data.imageUrl);
-                log.info("Session after update:", session);
+                log.info(LOG_CATEGORY, "Session updated with image:", data.imageUrl);
+                log.info(LOG_CATEGORY, "Session after update:", session);
 
                 setMessage("Profile image updated successfully!");
-                log.info("Session updated! Avatar should refresh automatically");
+                log.info(LOG_CATEGORY, "Session updated! Avatar should refresh automatically");
 
                 // Check session after update
                 setTimeout(() => {
-                    log.info("Checking session after update...");
+                    log.info(LOG_CATEGORY, "Checking session after update...");
                     // The session should now include the new image
                 }, 1000);
             } else {

--- a/app/api/applications/create/route.ts
+++ b/app/api/applications/create/route.ts
@@ -3,16 +3,18 @@ import { getServerSession } from "next-auth/next";
 import { log } from "app/shared/services";
 import { authOptions, prisma, invalidate, invalidatePattern } from "app/shared/services/server";
 
+const LOG_CATEGORY = "applications";
+
 export async function POST(request: NextRequest) {
     try {
-        log.info("🔍 Application creation API called");
+        log.info(LOG_CATEGORY, "🔍 Application creation API called");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("🔍 Session:", session ? "Found" : "Not found");
-        log.info("🔍 Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "🔍 Session:", session ? "Found" : "Not found");
+        log.info(LOG_CATEGORY, "🔍 Skip auth:", skipAuth);
 
         const body = await request.json();
         const { companyId, jobId, userId: bodyUserId } = body;
@@ -21,30 +23,30 @@ export async function POST(request: NextRequest) {
 
         if (skipAuth) {
             if (!bodyUserId) {
-                log.warn("❌ skip-auth mode but no userId provided in request");
+                log.warn(LOG_CATEGORY, "❌ skip-auth mode but no userId provided in request");
                 return NextResponse.json(
                     { error: "userId required when skip-auth=true" },
                     { status: 400 }
                 );
             }
             userId = bodyUserId;
-            log.info("✅ Skip auth - User ID from request:", userId);
+            log.info(LOG_CATEGORY, "✅ Skip auth - User ID from request:", userId);
         } else {
             if (!(session?.user as any)?.id) {
-                log.warn("❌ No user ID in session");
+                log.warn(LOG_CATEGORY, "❌ No user ID in session");
                 return NextResponse.json(
                     { error: "Unauthorized" },
                     { status: 401 }
                 );
             }
             userId = (session!.user as any).id;
-            log.info("✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "✅ User ID from session:", userId);
         }
 
-        log.info("📋 Request data:", { companyId, jobId });
+        log.info(LOG_CATEGORY, "📋 Request data:", { companyId, jobId });
 
         if (!companyId || !jobId) {
-            log.warn("❌ Missing required fields");
+            log.warn(LOG_CATEGORY, "❌ Missing required fields");
             return NextResponse.json(
                 {
                     error: "companyId and jobId are required",
@@ -54,24 +56,24 @@ export async function POST(request: NextRequest) {
         }
 
         // Find the company by ID
-        log.info("🏢 Looking for company:", companyId);
+        log.info(LOG_CATEGORY, "🏢 Looking for company:", companyId);
         const company = await prisma.company.findUnique({
             where: { id: companyId },
         });
 
         if (!company) {
-            log.warn("❌ Company not found:", companyId);
+            log.warn(LOG_CATEGORY, "❌ Company not found:", companyId);
             return NextResponse.json(
                 { error: "Company not found" },
                 { status: 404 }
             );
         }
-        log.info("✅ Company found:", company.name);
+        log.info(LOG_CATEGORY, "✅ Company found:", company.name);
 
         // Resolve job STRICTLY by jobId (deterministic)
         const job = await prisma.job.findUnique({ where: { id: jobId } });
         if (!job || job.companyId !== company.id) {
-            log.warn("❌ Job not found or does not belong to company", {
+            log.warn(LOG_CATEGORY, "❌ Job not found or does not belong to company", {
                 jobId,
                 companyId: company.id,
             });
@@ -87,7 +89,7 @@ export async function POST(request: NextRequest) {
         });
 
         if (existingByJobId) {
-            log.info(
+            log.info(LOG_CATEGORY, 
                 "✅ Reusing existing application by jobId:",
                 existingByJobId.id
             );
@@ -98,7 +100,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Create the application
-        log.info("🚀 Creating application...");
+        log.info(LOG_CATEGORY, "🚀 Creating application...");
         const application = await prisma.application.create({
             data: {
                 candidateId: userId,
@@ -107,7 +109,7 @@ export async function POST(request: NextRequest) {
             },
         });
 
-        log.info("✅ Application created:", application.id);
+        log.info(LOG_CATEGORY, "✅ Application created:", application.id);
         
         invalidate(`applicants:job:${job.id}`);
         invalidatePattern(`jobs:company:${company.name}`);
@@ -117,8 +119,8 @@ export async function POST(request: NextRequest) {
             application,
         });
     } catch (error) {
-        log.error("❌ Error creating application:", error);
-        log.error("❌ Error details:", {
+        log.error(LOG_CATEGORY, "❌ Error creating application:", error);
+        log.error(LOG_CATEGORY, "❌ Error details:", {
             name: error instanceof Error ? error.name : "Unknown",
             message: error instanceof Error ? error.message : String(error),
             stack: error instanceof Error ? error.stack : undefined,

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -3,6 +3,8 @@ import bcrypt from "bcryptjs";
 import { log } from "app/shared/services";
 import { prisma } from "app/shared/services/server";
 
+const LOG_CATEGORY = "auth-api";
+
 export async function POST(request: NextRequest) {
     try {
         const {
@@ -104,7 +106,7 @@ export async function POST(request: NextRequest) {
             { status: 201 }
         );
     } catch (error) {
-        log.error("Signup error:", error);
+        log.error(LOG_CATEGORY, "Signup error:", error);
         return NextResponse.json(
             { error: "Internal server error" },
             { status: 500 }

--- a/app/api/candidates/[id]/telemetry/route.ts
+++ b/app/api/candidates/[id]/telemetry/route.ts
@@ -4,6 +4,8 @@ import { getCached, setCached } from "app/shared/services/server";
 import prisma from "lib/prisma";
 import { calculateScore, type RawScores, type WorkstyleMetrics, type ScoringConfiguration } from "app/shared/utils/calculateScore";
 
+const LOG_CATEGORY = "telemetry";
+
 type RouteContext = {
     params: Promise<{ id?: string | string[] }>;
 };
@@ -20,7 +22,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         const { id } = await context.params;
         const candidateId = normalizeId(id);
 
-        log.info("[Telemetry API] GET request for candidateId:", candidateId);
+        log.info(LOG_CATEGORY, "[Telemetry API] GET request for candidateId:", candidateId);
 
         if (!candidateId) {
             return NextResponse.json(
@@ -29,7 +31,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             );
         }
         const applicationId = request.nextUrl.searchParams.get("applicationId");
-        log.info("[Telemetry API] applicationId:", applicationId);
+        log.info(LOG_CATEGORY, "[Telemetry API] applicationId:", applicationId);
 
         const cacheKey = `telemetry:candidate:${candidateId}:${applicationId ?? "all"}`;
         const cached = await getCached<any>(cacheKey);
@@ -110,7 +112,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
         const candidate = interviewSessions[0].candidate;
 
-        log.info("[Telemetry API] Found candidate:", candidate?.id, "Sessions:", interviewSessions.length);
+        log.info(LOG_CATEGORY, "[Telemetry API] Found candidate:", candidate?.id, "Sessions:", interviewSessions.length);
 
         // Fetch iterations for all sessions to generate evidence links
         const sessionIds = interviewSessions.map((s: any) => s.id);
@@ -233,9 +235,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
             iterationVideoChaptersBySession.get(sessionId)!.push(chapter);
         }
         
-        log.info("[Telemetry API] Fetched iteration video chapters:", iterationVideoChapters.length);
+        log.info(LOG_CATEGORY, "[Telemetry API] Fetched iteration video chapters:", iterationVideoChapters.length);
         iterationVideoChapters.forEach((chapter: any) => {
-            log.info(`  - ${chapter.title}: startTime=${chapter.startTime}s, sessionId=${chapter.telemetryData.interviewSessionId}`);
+            log.info(LOG_CATEGORY, `  - ${chapter.title}: startTime=${chapter.startTime}s, sessionId=${chapter.telemetryData.interviewSessionId}`);
         });
 
         // Group external tool usages by session
@@ -250,7 +252,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         // Transform sessions array
         const sessions = interviewSessions.map((session: any) => {
             try {
-                log.info("[Telemetry API] Processing session:", session.id, "videoUrl from DB:", session.videoUrl);
+                log.info(LOG_CATEGORY, "[Telemetry API] Processing session:", session.id, "videoUrl from DB:", session.videoUrl);
                 const telemetry = session.telemetryData;
                 const evidenceClips = telemetry?.evidenceClips || [];
                 const sessionIterations = iterationsBySession.get(session.id) || [];
@@ -265,9 +267,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
                 let totalScore = 0;
                 
                 if (session.recordingStartedAt && sessionExternalTools.length > 0) {
-                    log.info("🎬 [TELEMETRY EXTERNAL TOOLS OFFSET DEBUG] ============");
-                    log.info("📹 Recording started at:", new Date(session.recordingStartedAt).toISOString());
-                    log.info("📋 Processing", sessionExternalTools.length, "external tool events");
+                    log.info(LOG_CATEGORY, "🎬 [TELEMETRY EXTERNAL TOOLS OFFSET DEBUG] ============");
+                    log.info(LOG_CATEGORY, "📹 Recording started at:", new Date(session.recordingStartedAt).toISOString());
+                    log.info(LOG_CATEGORY, "📋 Processing", sessionExternalTools.length, "external tool events");
                     
                     sessionExternalTools.forEach((tool: any, index: number) => {
                         // Use aiQuestionTimestamp (when AI asks question and green highlight appears)
@@ -275,8 +277,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
                         const recordingStartTime = new Date(session.recordingStartedAt);
                         const videoOffset = (questionTime.getTime() - recordingStartTime.getTime()) / 1000;
                         
-                        log.info(`  [${index + 1}] AI Question at:`, questionTime.toISOString());
-                        log.info(`  [${index + 1}] Video offset:`, videoOffset, "seconds");
+                        log.info(LOG_CATEGORY, `  [${index + 1}] AI Question at:`, questionTime.toISOString());
+                        log.info(LOG_CATEGORY, `  [${index + 1}] Video offset:`, videoOffset, "seconds");
                         
                         if (videoOffset >= 0) {
                             aiAssistUsageLinks.push({
@@ -284,7 +286,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
                                 caption: tool.caption
                             });
                         } else {
-                            log.warn(`  [${index + 1}] ⚠️ NEGATIVE OFFSET - skipping!`);
+                            log.warn(LOG_CATEGORY, `  [${index + 1}] ⚠️ NEGATIVE OFFSET - skipping!`);
                         }
                         
                         // Count understanding levels
@@ -296,9 +298,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
                         totalScore += tool.accountabilityScore || 0;
                     });
                     
-                    log.info("🎯 Total evidence links for External Tools:", aiAssistUsageLinks.length);
-                    log.info("📍 Links:", aiAssistUsageLinks);
-                    log.info("================================================");
+                    log.info(LOG_CATEGORY, "🎯 Total evidence links for External Tools:", aiAssistUsageLinks.length);
+                    log.info(LOG_CATEGORY, "📍 Links:", aiAssistUsageLinks);
+                    log.info(LOG_CATEGORY, "================================================");
                 }
                 
                 const avgAccountabilityScore = sessionExternalTools.length > 0 
@@ -363,9 +365,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
                         const result = calculateScore(rawScores, workstyleMetrics, scoringConfig as ScoringConfiguration);
                         calculatedScore = result.finalScore;
-                        log.info(`[Telemetry API] Calculated score for session ${session.id}:`, calculatedScore);
+                        log.info(LOG_CATEGORY, `[Telemetry API] Calculated score for session ${session.id}:`, calculatedScore);
                     } catch (error) {
-                        log.error(`[Telemetry API] Error calculating score for session ${session.id}:`, error);
+                        log.error(LOG_CATEGORY, `[Telemetry API] Error calculating score for session ${session.id}:`, error);
                     }
                 }
 
@@ -409,7 +411,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
                     chapters: (() => {
                         const rawChapters = telemetry?.videoChapters || [];
                         
-                        log.info(`[Telemetry API] Session ${session.id} chapters:`, {
+                        log.info(LOG_CATEGORY, `[Telemetry API] Session ${session.id} chapters:`, {
                             totalCount: rawChapters.length,
                             titles: rawChapters.map((c: any) => c.title),
                             startTimes: rawChapters.map((c: any) => c.startTime)
@@ -419,7 +421,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
                         const seenChapters = new Set<string>();
                         const filtered = rawChapters.filter((chapter: any) => {
                             if (seenChapters.has(chapter.id)) {
-                                log.warn(`[Telemetry API] Duplicate chapter ID ${chapter.id} filtered`);
+                                log.warn(LOG_CATEGORY, `[Telemetry API] Duplicate chapter ID ${chapter.id} filtered`);
                                 return false;
                             }
                             seenChapters.add(chapter.id);
@@ -493,7 +495,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
                     confidenceCurve: telemetry?.confidenceCurve || [],
                 };
             } catch (sessionError) {
-                log.error("[Telemetry API] Error processing session:", session.id, sessionError);
+                log.error(LOG_CATEGORY, "[Telemetry API] Error processing session:", session.id, sessionError);
                 throw sessionError;
             }
         });
@@ -511,16 +513,16 @@ export async function GET(request: NextRequest, context: RouteContext) {
             sessions,
         };
 
-        log.info("[Telemetry API] Returning sessions count:", sessions.length);
-        log.info("[Telemetry API] First session videoUrl:", sessions[0]?.videoUrl);
+        log.info(LOG_CATEGORY, "[Telemetry API] Returning sessions count:", sessions.length);
+        log.info(LOG_CATEGORY, "[Telemetry API] First session videoUrl:", sessions[0]?.videoUrl);
 
         await setCached(cacheKey, response);
         return NextResponse.json(response);
     } catch (error) {
-        log.error("[Telemetry API GET] Error:", error);
+        log.error(LOG_CATEGORY, "[Telemetry API GET] Error:", error);
         if (error instanceof Error) {
-            log.error("[Telemetry API GET] Error message:", error.message);
-            log.error("[Telemetry API GET] Error stack:", error.stack);
+            log.error(LOG_CATEGORY, "[Telemetry API GET] Error message:", error.message);
+            log.error(LOG_CATEGORY, "[Telemetry API GET] Error stack:", error.stack);
         }
         return NextResponse.json(
             { error: "Failed to fetch telemetry data" },
@@ -680,7 +682,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
 
         return NextResponse.json({ success: true });
     } catch (error) {
-        log.error("Error updating candidate telemetry:", error);
+        log.error(LOG_CATEGORY, "Error updating candidate telemetry:", error);
         return NextResponse.json(
             { error: "Failed to update telemetry data" },
             { status: 500 }

--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import { log } from "app/shared/services";
 import { authOptions, prisma, getCached, setCached } from "app/shared/services/server";
 
+const LOG_CATEGORY = "companies";
+
 export async function GET(request: NextRequest) {
     try {
         const session = await getServerSession(authOptions);
@@ -113,7 +115,7 @@ export async function GET(request: NextRequest) {
             appliedJobIds,
         });
     } catch (error) {
-        log.error("Error fetching companies:", error);
+        log.error(LOG_CATEGORY, "Error fetching companies:", error);
         return NextResponse.json(
             {
                 error: `Failed to fetch companies: ${

--- a/app/api/company/candidates/route.ts
+++ b/app/api/company/candidates/route.ts
@@ -3,15 +3,17 @@ import { getServerSession } from "next-auth/next";
 import { log } from "app/shared/services";
 import { authOptions, prisma } from "app/shared/services/server";
 
+const LOG_CATEGORY = "company";
+
 export async function GET(request: NextRequest) {
     try {
-        log.info("🔍 Company candidates API called");
+        log.info(LOG_CATEGORY, "🔍 Company candidates API called");
 
         const session = await getServerSession(authOptions);
-        log.info("🔍 Session:", session ? "Found" : "Not found");
+        log.info(LOG_CATEGORY, "🔍 Session:", session ? "Found" : "Not found");
 
         if (!(session?.user as any)?.id) {
-            log.warn("❌ No user ID in session");
+            log.warn(LOG_CATEGORY, "❌ No user ID in session");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -19,55 +21,55 @@ export async function GET(request: NextRequest) {
         }
 
         const userId = (session!.user as any).id;
-        log.info("✅ User ID:", userId);
+        log.info(LOG_CATEGORY, "✅ User ID:", userId);
 
         // Get the user's company profile
-        log.info("🏢 Looking for company profile...");
+        log.info(LOG_CATEGORY, "🏢 Looking for company profile...");
         const companyProfile = await prisma.companyProfile.findUnique({
             where: { userId: userId },
         });
 
         if (!companyProfile) {
-            log.warn("❌ Company profile not found for user:", userId);
+            log.warn(LOG_CATEGORY, "❌ Company profile not found for user:", userId);
             return NextResponse.json(
                 { error: "Company profile not found" },
                 { status: 404 }
             );
         }
 
-        log.info("✅ Company profile found:", companyProfile.companyName);
+        log.info(LOG_CATEGORY, "✅ Company profile found:", companyProfile.companyName);
 
         const { searchParams } = new URL(request.url);
         const jobRole = searchParams.get("jobRole");
 
         // Find the company by name
-        log.info("🏢 Looking for company:", companyProfile.companyName);
+        log.info(LOG_CATEGORY, "🏢 Looking for company:", companyProfile.companyName);
         const company = await prisma.company.findUnique({
             where: { name: companyProfile.companyName },
         });
 
         if (!company) {
-            log.warn("❌ Company not found:", companyProfile.companyName);
+            log.warn(LOG_CATEGORY, "❌ Company not found:", companyProfile.companyName);
             return NextResponse.json(
                 { error: "Company not found" },
                 { status: 404 }
             );
         }
 
-        log.info("✅ Company found:", company.id);
+        log.info(LOG_CATEGORY, "✅ Company found:", company.id);
 
         // Find all jobs for this company
-        log.info("💼 Looking for jobs...");
+        log.info(LOG_CATEGORY, "💼 Looking for jobs...");
         const jobs = await prisma.job.findMany({
             where: { companyId: company.id },
             select: { id: true },
         });
 
-        log.info("✅ Found", jobs.length, "jobs");
+        log.info(LOG_CATEGORY, "✅ Found", jobs.length, "jobs");
         const jobIds = jobs.map((job) => job.id);
 
         // Get all applications for this company's jobs
-        log.info("📋 Looking for applications...");
+        log.info(LOG_CATEGORY, "📋 Looking for applications...");
         const applications = await (prisma as any).application.findMany({
             where: {
                 jobId: { in: jobIds },
@@ -86,7 +88,7 @@ export async function GET(request: NextRequest) {
             },
         });
 
-        log.info("✅ Found", applications.length, "applications");
+        log.info(LOG_CATEGORY, "✅ Found", applications.length, "applications");
 
         // Filter by job role if provided
         let filteredApplications = applications;
@@ -140,8 +142,8 @@ export async function GET(request: NextRequest) {
             total: candidates.length,
         });
     } catch (error) {
-        log.error("❌ Error fetching company candidates:", error);
-        log.error("❌ Error details:", {
+        log.error(LOG_CATEGORY, "❌ Error fetching company candidates:", error);
+        log.error(LOG_CATEGORY, "❌ Error details:", {
             name: error instanceof Error ? error.name : "Unknown",
             message: error instanceof Error ? error.message : String(error),
             stack: error instanceof Error ? error.stack : undefined,

--- a/app/api/company/jobs/[jobId]/route.ts
+++ b/app/api/company/jobs/[jobId]/route.ts
@@ -5,6 +5,8 @@ import { authOptions, prisma, invalidatePattern, invalidate } from "app/shared/s
 import { loadCompanyForUser } from "../companyContext";
 import { mapJobResponse, coerceSeconds } from "../jobHelpers";
 
+const LOG_CATEGORY = "company";
+
 type RouteContext = {
     params: Promise<{ jobId?: string | string[] }>;
 };
@@ -89,7 +91,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
             }
             return 500;
         })();
-        log.error("❌ Failed to fetch company job detail:", error);
+        log.error(LOG_CATEGORY, "❌ Failed to fetch company job detail:", error);
         return NextResponse.json({ error: message }, { status });
     }
 }
@@ -307,7 +309,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
             }
             return 500;
         })();
-        log.error("❌ Failed to update company job:", error);
+        log.error(LOG_CATEGORY, "❌ Failed to update company job:", error);
         return NextResponse.json({ error: message }, { status });
     }
 }
@@ -370,7 +372,7 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
             }
             return 500;
         })();
-        log.error("❌ Failed to delete company job:", error);
+        log.error(LOG_CATEGORY, "❌ Failed to delete company job:", error);
         return NextResponse.json({ error: message }, { status });
     }
 }

--- a/app/api/company/jobs/[jobId]/scoring-config/route.ts
+++ b/app/api/company/jobs/[jobId]/scoring-config/route.ts
@@ -5,6 +5,8 @@ import prisma from "lib/prisma";
 import { log } from "app/shared/services";
 import { loadCompanyForUser } from "../../companyContext";
 
+const LOG_CATEGORY = "company";
+
 interface RouteContext {
     params: Promise<{ jobId: string }>;
 }
@@ -54,7 +56,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
                 config = await prisma.scoringConfiguration.create({
                     data: { jobId },
                 });
-                log.info(`[scoring-config/GET] Created default configuration for job ${jobId}`);
+                log.info(LOG_CATEGORY, `[scoring-config/GET] Created default configuration for job ${jobId}`);
             }
 
             return NextResponse.json({ config });
@@ -92,12 +94,12 @@ export async function GET(request: NextRequest, context: RouteContext) {
             config = await prisma.scoringConfiguration.create({
                 data: { jobId },
             });
-            log.info(`[scoring-config/GET] Created default configuration for job ${jobId}`);
+            log.info(LOG_CATEGORY, `[scoring-config/GET] Created default configuration for job ${jobId}`);
         }
 
         return NextResponse.json({ config });
     } catch (error: any) {
-        log.error("[scoring-config/GET] Error:", error);
+        log.error(LOG_CATEGORY, "[scoring-config/GET] Error:", error);
         const message = error.message || "Failed to fetch scoring configuration";
         const status = error.message?.includes("Forbidden") ? 403 : 500;
         return NextResponse.json({ error: message }, { status });
@@ -209,11 +211,11 @@ export async function PUT(request: NextRequest, context: RouteContext) {
             update: updates,
         });
 
-        log.info(`[scoring-config/PUT] Updated configuration for job ${jobId}`);
+        log.info(LOG_CATEGORY, `[scoring-config/PUT] Updated configuration for job ${jobId}`);
 
         return NextResponse.json({ config });
     } catch (error: any) {
-        log.error("[scoring-config/PUT] Error:", error);
+        log.error(LOG_CATEGORY, "[scoring-config/PUT] Error:", error);
         const message = error.message || "Failed to update scoring configuration";
         const status = error.message?.includes("Forbidden") ? 403 : 500;
         return NextResponse.json({ error: message }, { status });

--- a/app/api/company/jobs/companyContext.ts
+++ b/app/api/company/jobs/companyContext.ts
@@ -2,6 +2,8 @@ import { Company, CompanyProfile } from "@prisma/client";
 import { log } from "app/shared/services";
 import { prisma } from "app/shared/services/server";
 
+const LOG_CATEGORY = "company";
+
 export interface CompanyContext {
     company: Company;
     profile: CompanyProfile;
@@ -15,7 +17,7 @@ export async function loadCompanyForUser(userId: string): Promise<CompanyContext
         where: { userId },
     });
     if (!profile) {
-        log.warn("Company profile not found for user", { userId });
+        log.warn(LOG_CATEGORY, "Company profile not found for user", { userId });
         throw new Error("Company profile not found for user");
     }
 
@@ -23,7 +25,7 @@ export async function loadCompanyForUser(userId: string): Promise<CompanyContext
         where: { name: profile.companyName },
     });
     if (!company) {
-        log.warn("Company record not found for profile", {
+        log.warn(LOG_CATEGORY, "Company record not found for profile", {
             companyName: profile.companyName,
         });
         throw new Error("Company record not found for profile");

--- a/app/api/company/jobs/route.ts
+++ b/app/api/company/jobs/route.ts
@@ -5,6 +5,8 @@ import { authOptions, prisma, invalidatePattern } from "app/shared/services/serv
 import { loadCompanyForUser } from "./companyContext";
 import { coerceSeconds, mapJobResponse } from "./jobHelpers";
 
+const LOG_CATEGORY = "company";
+
 function ensureCompanyRole(session: any) {
     const role = session?.user?.role;
     if (role !== "COMPANY") {
@@ -42,7 +44,7 @@ export async function GET(_request: NextRequest) {
             jobs: jobs.map((job: any) => mapJobResponse(job, company)),
         });
     } catch (error) {
-        log.error("❌ Failed to list company jobs:", error);
+        log.error(LOG_CATEGORY, "❌ Failed to list company jobs:", error);
         const message = error instanceof Error ? error.message : "Unknown error";
         const status = message === "Company role required" ? 403 : 500;
         return NextResponse.json({ error: message }, { status });
@@ -190,7 +192,7 @@ export async function POST(request: NextRequest) {
         invalidatePattern("companies:list:");
         return NextResponse.json(mapJobResponse(job, job.company));
     } catch (error) {
-        log.error("❌ Failed to create company job:", error);
+        log.error(LOG_CATEGORY, "❌ Failed to create company job:", error);
         const message = error instanceof Error ? error.message : "Unknown error";
         const status = (() => {
             if (message === "Company role required") {

--- a/app/api/interviews/evaluate-answer/route.ts
+++ b/app/api/interviews/evaluate-answer/route.ts
@@ -4,6 +4,8 @@ import prisma from "lib/prisma";
 import OpenAI from "openai";
 import { createVideoChapter } from "../shared/createVideoChapter";
 
+const LOG_CATEGORY = "interviews";
+
 const openai = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -24,7 +26,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[evaluate-answer] Evaluating answer for session:", sessionId);
+        log.info(LOG_CATEGORY, "[evaluate-answer] Evaluating answer for session:", sessionId);
 
         // Fetch session with recording data and job
         const session = await prisma.interviewSession.findUnique({
@@ -53,7 +55,7 @@ export async function POST(request: NextRequest) {
         }
 
         if (!categoriesToEvaluate || categoriesToEvaluate.length === 0) {
-            log.info("[evaluate-answer] No experience categories defined for this job - skipping evaluation");
+            log.info(LOG_CATEGORY, "[evaluate-answer] No experience categories defined for this job - skipping evaluation");
             return NextResponse.json({
                 success: true,
                 contributionsCount: 0,
@@ -109,7 +111,7 @@ CRITICAL RULES:
 - Blank or gibberish answers MUST be scored 0 across all categories.
 - Be strict with 0 scores - use them for noise, blank answers, and gibberish.`;
 
-        log.info("[evaluate-answer] Calling OpenAI for evaluation");
+        log.info(LOG_CATEGORY, "[evaluate-answer] Calling OpenAI for evaluation");
 
         const completion = await openai.chat.completions.create({
             model: "gpt-4o",
@@ -132,7 +134,7 @@ CRITICAL RULES:
         }
 
         const evaluation = JSON.parse(responseText);
-        log.info("[evaluate-answer] OpenAI evaluation:", evaluation);
+        log.info(LOG_CATEGORY, "[evaluate-answer] OpenAI evaluation:", evaluation);
 
         // Process evaluations - only create records for non-zero scores
         const contributions: Array<{
@@ -157,7 +159,7 @@ CRITICAL RULES:
                     },
                 });
 
-                log.info(`[evaluate-answer] Created contribution for ${item.category}:`, contribution.id);
+                log.info(LOG_CATEGORY, `[evaluate-answer] Created contribution for ${item.category}:`, contribution.id);
 
                 // Calculate video offset
                 let videoOffset = 0;
@@ -183,7 +185,7 @@ CRITICAL RULES:
                     },
                 });
 
-                log.info(`[evaluate-answer] Created evidence clip for ${item.category}:`, evidenceClip.id);
+                log.info(LOG_CATEGORY, `[evaluate-answer] Created evidence clip for ${item.category}:`, evidenceClip.id);
 
                 // Create VideoChapter
                 await createVideoChapter({
@@ -203,7 +205,7 @@ CRITICAL RULES:
             }
         }
 
-        log.info(`[evaluate-answer] ✅ Evaluation complete. ${contributions.length} contributions with strength > 0.`);
+        log.info(LOG_CATEGORY, `[evaluate-answer] ✅ Evaluation complete. ${contributions.length} contributions with strength > 0.`);
 
         // Calculate updated category counts
         const updatedCounts = await prisma.categoryContribution.groupBy({
@@ -219,7 +221,7 @@ CRITICAL RULES:
             avgStrength: Math.round(item._avg.contributionStrength || 0),
         }));
 
-        log.info(`[evaluate-answer] Updated category stats:`, categoryStats);
+        log.info(LOG_CATEGORY, `[evaluate-answer] Updated category stats:`, categoryStats);
 
         return NextResponse.json({
             success: true,
@@ -229,7 +231,7 @@ CRITICAL RULES:
             updatedCounts: categoryStats,
         });
     } catch (error) {
-        log.error("[evaluate-answer] ❌ Error:", error);
+        log.error(LOG_CATEGORY, "[evaluate-answer] ❌ Error:", error);
         return NextResponse.json(
             { error: error instanceof Error ? error.message : "Unknown error" },
             { status: 500 }

--- a/app/api/interviews/evaluate-code-change/route.ts
+++ b/app/api/interviews/evaluate-code-change/route.ts
@@ -4,6 +4,8 @@ import prisma from "lib/prisma";
 import OpenAI from "openai";
 import { createVideoChapter } from "../shared/createVideoChapter";
 
+const LOG_CATEGORY = "interviews";
+
 const openai = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -24,7 +26,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[evaluate-code-change] Evaluating code change for session:", sessionId);
+        log.info(LOG_CATEGORY, "[evaluate-code-change] Evaluating code change for session:", sessionId);
 
         // Fetch session with recording data
         const session = await prisma.interviewSession.findUnique({
@@ -98,7 +100,7 @@ For EVERY category, return:
 
 Be strict with 0 scores - use them for noise. But use the full range 1-100 for legitimate code.`;
 
-        log.info("[evaluate-code-change] Calling OpenAI for evaluation");
+        log.info(LOG_CATEGORY, "[evaluate-code-change] Calling OpenAI for evaluation");
 
         const completion = await openai.chat.completions.create({
             model: "gpt-4o",
@@ -125,7 +127,7 @@ Be strict with 0 scores - use them for noise. But use the full range 1-100 for l
         const allEvaluations = evaluationResult.evaluations || [];
         const contributions = allEvaluations.filter((e: any) => e.strength > 0);
 
-        log.info(`[evaluate-code-change] Found ${contributions.length} contributions with strength > 0 out of ${allEvaluations.length} evaluations`);
+        log.info(LOG_CATEGORY, `[evaluate-code-change] Found ${contributions.length} contributions with strength > 0 out of ${allEvaluations.length} evaluations`);
 
         // Calculate video offset
         const changeTimestamp = new Date(timestamp);
@@ -138,7 +140,7 @@ Be strict with 0 scores - use them for noise. But use the full range 1-100 for l
 
         // Create evidence clips and contribution records for each contribution with strength > 0
         for (const contribution of contributions) {
-            log.info(`[evaluate-code-change] Creating evidence for ${contribution.category} (strength: ${contribution.strength})`);
+            log.info(LOG_CATEGORY, `[evaluate-code-change] Creating evidence for ${contribution.category} (strength: ${contribution.strength})`);
 
             // 1. Create CategoryContribution record
             await prisma.categoryContribution.create({
@@ -181,7 +183,7 @@ Be strict with 0 scores - use them for noise. But use the full range 1-100 for l
                 });
             }
 
-            log.info(`[evaluate-code-change] ✅ Created evidence for ${contribution.category} at ${videoOffset}s`);
+            log.info(LOG_CATEGORY, `[evaluate-code-change] ✅ Created evidence for ${contribution.category} at ${videoOffset}s`);
         }
 
         return NextResponse.json({
@@ -195,7 +197,7 @@ Be strict with 0 scores - use them for noise. But use the full range 1-100 for l
             })),
         });
     } catch (error: any) {
-        log.error("[evaluate-code-change] Error evaluating code change:", error);
+        log.error(LOG_CATEGORY, "[evaluate-code-change] Error evaluating code change:", error);
         return NextResponse.json(
             {
                 error: "Failed to evaluate code change",

--- a/app/api/interviews/evaluate-job-specific-coding/route.ts
+++ b/app/api/interviews/evaluate-job-specific-coding/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 const openaiClient = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -18,7 +20,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[Job-Specific Coding Eval] Evaluating code against categories:", categories.length);
+        log.info(LOG_CATEGORY, "[Job-Specific Coding Eval] Evaluating code against categories:", categories.length);
 
         // Build category list for prompt
         const categoryList = categories
@@ -90,11 +92,11 @@ Return ONLY valid JSON with this exact structure:
             throw new Error("Invalid response structure from OpenAI");
         }
 
-        log.info("[Job-Specific Coding Eval] Evaluation complete");
+        log.info(LOG_CATEGORY, "[Job-Specific Coding Eval] Evaluation complete");
 
         return NextResponse.json(result);
     } catch (error: any) {
-        log.error("[Job-Specific Coding Eval] Error:", error);
+        log.error(LOG_CATEGORY, "[Job-Specific Coding Eval] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to evaluate job-specific coding",

--- a/app/api/interviews/evaluate-paste-accountability/route.ts
+++ b/app/api/interviews/evaluate-paste-accountability/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 const openaiClient = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -30,7 +32,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info(`[Paste Accountability] Evaluating Q${questionNumber || '?'} understanding...`);
+        log.info(LOG_CATEGORY, `[Paste Accountability] Evaluating Q${questionNumber || '?'} understanding...`);
 
         // Build prompt based on whether we have topics (Phase 2) or not (Phase 1)
         const hasTopics = currentTopicCoverage && Object.keys(currentTopicCoverage).length > 0;
@@ -164,11 +166,11 @@ Return ONLY valid JSON with this exact structure:
             }
         }
 
-        log.info(`[Paste Accountability] Q${questionNumber || '?'} score: ${result.score}`);
+        log.info(LOG_CATEGORY, `[Paste Accountability] Q${questionNumber || '?'} score: ${result.score}`);
 
         return NextResponse.json(result);
     } catch (error: any) {
-        log.error("[Paste Accountability] Error:", error);
+        log.error(LOG_CATEGORY, "[Paste Accountability] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to evaluate paste accountability",

--- a/app/api/interviews/generate-coding-gaps/route.ts
+++ b/app/api/interviews/generate-coding-gaps/route.ts
@@ -3,11 +3,13 @@ import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 import OpenAI from "openai";
 
+const LOG_CATEGORY = "interviews";
+
 export async function POST(request: NextRequest) {
     try {
         const openaiApiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
         if (!openaiApiKey) {
-            log.error("[Generate Coding Gaps] OpenAI API key not configured");
+            log.error(LOG_CATEGORY, "[Generate Coding Gaps] OpenAI API key not configured");
             return NextResponse.json(
                 { error: "OpenAI API key not configured" },
                 { status: 500 }
@@ -26,7 +28,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[Generate Coding Gaps] Starting gap generation for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] Starting gap generation for session:", sessionId);
 
         // Fetch all coding session metrics
         const [iterations, externalToolUsages] = await Promise.all([
@@ -50,7 +52,7 @@ export async function POST(request: NextRequest) {
             }),
         ]);
 
-        log.info("[Generate Coding Gaps] Metrics gathered:", {
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] Metrics gathered:", {
             iterations: iterations.length,
             externalToolUsages: externalToolUsages.length,
         });
@@ -130,7 +132,7 @@ ${JSON.stringify(metricsContext, null, 2)}
 
 Identify gaps in the candidate's skills based on this data.`;
 
-        log.info("[Generate Coding Gaps] Calling OpenAI...");
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] Calling OpenAI...");
 
         const completion = await openaiClient.chat.completions.create({
             model: "gpt-4o",
@@ -147,12 +149,12 @@ Identify gaps in the candidate's skills based on this data.`;
             throw new Error("No response from OpenAI");
         }
 
-        log.info("[Generate Coding Gaps] OpenAI response received");
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] OpenAI response received");
 
         const parsed = JSON.parse(responseText);
         const gaps = parsed.gaps || [];
 
-        log.info("[Generate Coding Gaps] Parsed gaps:", gaps.length);
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] Parsed gaps:", gaps.length);
 
         // Get telemetry data for this session
         const session = await prisma.interviewSession.findUnique({
@@ -161,7 +163,7 @@ Identify gaps in the candidate's skills based on this data.`;
         });
 
         if (!session?.telemetryData?.gapAnalysis) {
-            log.error("[Generate Coding Gaps] No gap analysis found for session");
+            log.error(LOG_CATEGORY, "[Generate Coding Gaps] No gap analysis found for session");
             return NextResponse.json(
                 { error: "Gap analysis not found for session" },
                 { status: 404 }
@@ -189,7 +191,7 @@ Identify gaps in the candidate's skills based on this data.`;
             });
         }
 
-        log.info("[Generate Coding Gaps] Gaps saved to database");
+        log.info(LOG_CATEGORY, "[Generate Coding Gaps] Gaps saved to database");
 
         return NextResponse.json({
             message: "Gaps generated successfully",
@@ -197,7 +199,7 @@ Identify gaps in the candidate's skills based on this data.`;
             gaps,
         });
     } catch (error: any) {
-        log.error("[Generate Coding Gaps] Error:", error);
+        log.error(LOG_CATEGORY, "[Generate Coding Gaps] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to generate gaps",

--- a/app/api/interviews/generate-coding-summary/route.ts
+++ b/app/api/interviews/generate-coding-summary/route.ts
@@ -4,11 +4,13 @@ import prisma from "lib/prisma";
 import OpenAI from "openai";
 import { calculateScore, type RawScores, type WorkstyleMetrics } from "app/shared/utils/calculateScore";
 
+const LOG_CATEGORY = "interviews";
+
 export async function POST(request: NextRequest) {
     try {
         const openaiApiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
         if (!openaiApiKey) {
-            log.error("[Generate Coding Summary] OpenAI API key not configured");
+            log.error(LOG_CATEGORY, "[Generate Coding Summary] OpenAI API key not configured");
             return NextResponse.json(
                 { error: "OpenAI API key not configured" },
                 { status: 500 }
@@ -27,7 +29,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[Generate Coding Summary] Starting summary generation for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] Starting summary generation for session:", sessionId);
 
         // Fetch session with application and job to get scoring configuration
         const session = await prisma.interviewSession.findUnique({
@@ -84,7 +86,7 @@ export async function POST(request: NextRequest) {
             }),
         ]);
 
-        log.info("[Generate Coding Summary] Metrics gathered:", {
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] Metrics gathered:", {
             iterations: iterations.length,
             externalToolUsages: externalToolUsages.length,
         });
@@ -180,7 +182,7 @@ ${JSON.stringify(metricsContext, null, 2)}
 
 Provide a comprehensive summary and scores for this candidate's coding performance.`;
 
-        log.info("[Generate Coding Summary] Calling OpenAI...");
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] Calling OpenAI...");
 
         const completion = await openaiClient.chat.completions.create({
             model: "gpt-4o",
@@ -197,14 +199,14 @@ Provide a comprehensive summary and scores for this candidate's coding performan
             throw new Error("No response from OpenAI");
         }
 
-        log.info("[Generate Coding Summary] OpenAI response received");
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] OpenAI response received");
 
         const parsed = JSON.parse(responseText);
 
-        log.info("[Generate Coding Summary] Parsed summary");
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] Parsed summary");
 
         if (!session?.telemetryData) {
-            log.error("[Generate Coding Summary] No telemetry data found for session");
+            log.error(LOG_CATEGORY, "[Generate Coding Summary] No telemetry data found for session");
             return NextResponse.json(
                 { error: "Telemetry data not found for session" },
                 { status: 404 }
@@ -234,7 +236,7 @@ Provide a comprehensive summary and scores for this candidate's coding performan
             },
         });
 
-        log.info("[Generate Coding Summary] Summary saved to database");
+        log.info(LOG_CATEGORY, "[Generate Coding Summary] Summary saved to database");
 
         // Calculate and save final score if we have all required data
         let finalScore: number | null = null;
@@ -260,9 +262,9 @@ Provide a comprehensive summary and scores for this candidate's coding performan
                     data: { finalScore },
                 });
 
-                log.info(`[Generate Coding Summary] Calculated and saved finalScore=${finalScore} for session ${sessionId}`);
+                log.info(LOG_CATEGORY, `[Generate Coding Summary] Calculated and saved finalScore=${finalScore} for session ${sessionId}`);
             } catch (error) {
-                log.error("[Generate Coding Summary] Score calculation error:", error);
+                log.error(LOG_CATEGORY, "[Generate Coding Summary] Score calculation error:", error);
             }
         }
 
@@ -272,7 +274,7 @@ Provide a comprehensive summary and scores for this candidate's coding performan
             finalScore,
         });
     } catch (error: any) {
-        log.error("[Generate Coding Summary] Error:", error);
+        log.error(LOG_CATEGORY, "[Generate Coding Summary] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to generate coding summary",

--- a/app/api/interviews/generate-paste-summary/route.ts
+++ b/app/api/interviews/generate-paste-summary/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 const openaiClient = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -18,7 +20,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[Paste Summary] Generating final summary...");
+        log.info(LOG_CATEGORY, "[Paste Summary] Generating final summary...");
 
         // Build Q&A history string
         const qaHistory = questionAnswers
@@ -60,11 +62,11 @@ Return ONLY the summary text (no JSON, no extra formatting).`;
             throw new Error("Empty response from OpenAI");
         }
 
-        log.info("[Paste Summary] Summary generated successfully");
+        log.info(LOG_CATEGORY, "[Paste Summary] Summary generated successfully");
 
         return NextResponse.json({ summary });
     } catch (error: any) {
-        log.error("[Paste Summary] Error:", error);
+        log.error(LOG_CATEGORY, "[Paste Summary] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to generate paste summary",

--- a/app/api/interviews/identify-paste-topics/route.ts
+++ b/app/api/interviews/identify-paste-topics/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 const openaiClient = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
@@ -30,7 +32,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info("[Topic Identification] Analyzing pasted code for topics...");
+        log.info(LOG_CATEGORY, "[Topic Identification] Analyzing pasted code for topics...");
 
         const systemPrompt = `You are analyzing code a candidate pasted during an interview.
 
@@ -98,11 +100,11 @@ Maximum 3-4 topics to ensure comprehensive evaluation without overwhelming the c
             }
         }
 
-        log.info("[Topic Identification] Identified topics:", result.topics.length);
+        log.info(LOG_CATEGORY, "[Topic Identification] Identified topics:", result.topics.length);
 
         return NextResponse.json(result);
     } catch (error: any) {
-        log.error("[Topic Identification] Error:", error);
+        log.error(LOG_CATEGORY, "[Topic Identification] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to identify paste topics",

--- a/app/api/interviews/session/[sessionId]/background-chapters/route.ts
+++ b/app/api/interviews/session/[sessionId]/background-chapters/route.ts
@@ -6,6 +6,8 @@ import prisma from "lib/prisma";
 import { createVideoChapter } from "../../../shared/createVideoChapter";
 import { CHAPTER_TYPES } from "../../../shared/chapterTypes";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -23,14 +25,14 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
  */
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[background-chapters/POST] ========== START ==========");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] ========== START ==========");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("[background-chapters/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
-        log.info("[background-chapters/POST] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Skip auth:", skipAuth);
 
         const body = await request.json();
         const { userId: requestUserId } = body;
@@ -39,29 +41,29 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
         if (skipAuth) {
             if (!requestUserId) {
-                log.warn("[background-chapters/POST] ❌ skip-auth mode but no userId provided in request");
+                log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ skip-auth mode but no userId provided in request");
                 return NextResponse.json(
                     { error: "userId required when skip-auth=true" },
                     { status: 400 }
                 );
             }
             userId = requestUserId;
-            log.info("[background-chapters/POST] ✅ Skip auth - User ID from request:", userId);
+            log.info(LOG_CATEGORY, "[background-chapters/POST] ✅ Skip auth - User ID from request:", userId);
         } else {
             if (!session?.user) {
-                log.warn("[background-chapters/POST] ❌ Unauthorized request");
+                log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ Unauthorized request");
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
             userId = (session.user as any).id;
-            log.info("[background-chapters/POST] ✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "[background-chapters/POST] ✅ User ID from session:", userId);
         }
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
-        log.info("[background-chapters/POST] sessionId:", sessionId);
+        log.info(LOG_CATEGORY, "[background-chapters/POST] sessionId:", sessionId);
 
         if (!sessionId) {
-            log.warn("[background-chapters/POST] ❌ Interview session id was not provided");
+            log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ Interview session id was not provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
@@ -69,7 +71,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Verify the interview session exists and belongs to the user
-        log.info("[background-chapters/POST] Looking up interview session...");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Looking up interview session...");
         const interviewSession = await prisma.interviewSession.findFirst({
             where: {
                 id: sessionId,
@@ -81,7 +83,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.warn("[background-chapters/POST] ❌ Interview session not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ Interview session not found or doesn't belong to user");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -89,7 +91,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         if (!interviewSession.telemetryData) {
-            log.warn("[background-chapters/POST] ❌ No telemetry data found for session");
+            log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ No telemetry data found for session");
             return NextResponse.json(
                 { error: "Telemetry data not found" },
                 { status: 404 }
@@ -97,19 +99,19 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         if (!interviewSession.recordingStartedAt) {
-            log.warn("[background-chapters/POST] ❌ No recording start time found");
+            log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ No recording start time found");
             return NextResponse.json(
                 { error: "Recording start time not found" },
                 { status: 400 }
             );
         }
 
-        log.info("[background-chapters/POST] ✅ Interview session found:", interviewSession.id);
+        log.info(LOG_CATEGORY, "[background-chapters/POST] ✅ Interview session found:", interviewSession.id);
         const telemetryDataId = interviewSession.telemetryData.id;
         const recordingStartTime = interviewSession.recordingStartedAt;
 
         // Fetch background conversation messages
-        log.info("[background-chapters/POST] Fetching conversation messages...");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Fetching conversation messages...");
         const messages = await prisma.conversationMessage.findMany({
             where: {
                 interviewSessionId: sessionId,
@@ -120,10 +122,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-chapters/POST] Found", messages.length, "background messages");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Found", messages.length, "background messages");
 
         if (messages.length === 0) {
-            log.warn("[background-chapters/POST] ❌ No background messages found");
+            log.warn(LOG_CATEGORY, "[background-chapters/POST] ❌ No background messages found");
             return NextResponse.json(
                 { error: "No background conversation found" },
                 { status: 400 }
@@ -131,7 +133,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Fetch background evidence
-        log.info("[background-chapters/POST] Fetching background evidence...");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Fetching background evidence...");
         const evidenceLinks = await prisma.backgroundEvidence.findMany({
             where: {
                 telemetryDataId,
@@ -141,21 +143,21 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-chapters/POST] Found", evidenceLinks.length, "evidence links");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Found", evidenceLinks.length, "evidence links");
 
         // Determine chapter start time
         let chapterStartTimestamp: Date;
         if (evidenceLinks.length > 0) {
             chapterStartTimestamp = evidenceLinks[0].timestamp;
-            log.info("[background-chapters/POST] Using first evidence timestamp:", chapterStartTimestamp.toISOString());
+            log.info(LOG_CATEGORY, "[background-chapters/POST] Using first evidence timestamp:", chapterStartTimestamp.toISOString());
         } else {
             chapterStartTimestamp = messages[0].timestamp;
-            log.info("[background-chapters/POST] Using first message timestamp:", chapterStartTimestamp.toISOString());
+            log.info(LOG_CATEGORY, "[background-chapters/POST] Using first message timestamp:", chapterStartTimestamp.toISOString());
         }
 
         // Calculate start time in seconds from recording start
         const startTimeSeconds = (chapterStartTimestamp.getTime() - recordingStartTime.getTime()) / 1000;
-        log.info("[background-chapters/POST] Chapter start time:", startTimeSeconds, "seconds");
+        log.info(LOG_CATEGORY, "[background-chapters/POST] Chapter start time:", startTimeSeconds, "seconds");
 
         // Create chapter without caption (captions will be created by background-summary based on analysis)
         await createChapterWithCaption(telemetryDataId, startTimeSeconds);
@@ -165,7 +167,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             { status: 202 }
         );
     } catch (error) {
-        log.error("❌ Error generating background chapters:", error);
+        log.error(LOG_CATEGORY, "❌ Error generating background chapters:", error);
         return NextResponse.json(
             { error: "Failed to generate background chapters" },
             { status: 500 }
@@ -180,7 +182,7 @@ async function createChapterWithCaption(
     telemetryDataId: string,
     startTimeSeconds: number
 ) {
-    log.info("[createChapterWithCaption] Creating Background chapter...");
+    log.info(LOG_CATEGORY, "[createChapterWithCaption] Creating Background chapter...");
     
     await createVideoChapter({
         telemetryDataId,
@@ -190,5 +192,5 @@ async function createChapterWithCaption(
         // No caption initially - will be populated by background-summary with analysis results
     });
     
-    log.info("[createChapterWithCaption] ✅ Background chapter created");
+    log.info(LOG_CATEGORY, "[createChapterWithCaption] ✅ Background chapter created");
 }

--- a/app/api/interviews/session/[sessionId]/background-evidence/[evidenceId]/route.ts
+++ b/app/api/interviews/session/[sessionId]/background-evidence/[evidenceId]/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[]; evidenceId?: string | string[] }>;
 };
@@ -21,14 +23,14 @@ function normalizeId(id: string | string[] | undefined) {
  */
 export async function PATCH(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[background-evidence/[evidenceId]/PATCH] ========== START ==========");
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ========== START ==========");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("[background-evidence/[evidenceId]/PATCH] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
-        log.info("[background-evidence/[evidenceId]/PATCH] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] Skip auth:", skipAuth);
 
         const body = await request.json();
         const { duration, userId: requestUserId } = body;
@@ -37,25 +39,25 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
         if (skipAuth) {
             userId = requestUserId || "";
-            log.info("[background-evidence/[evidenceId]/PATCH] Skip auth - User ID from request:", userId || "(not provided)");
+            log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] Skip auth - User ID from request:", userId || "(not provided)");
         } else {
             if (!session?.user) {
-                log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Unauthorized request");
+                log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Unauthorized request");
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
             userId = (session.user as any).id;
-            log.info("[background-evidence/[evidenceId]/PATCH] ✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ✅ User ID from session:", userId);
         }
 
         const { sessionId: rawSessionId, evidenceId: rawEvidenceId } = await context.params;
         const sessionId = normalizeId(rawSessionId);
         const evidenceId = normalizeId(rawEvidenceId);
 
-        log.info("[background-evidence/[evidenceId]/PATCH] sessionId:", sessionId);
-        log.info("[background-evidence/[evidenceId]/PATCH] evidenceId:", evidenceId);
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] sessionId:", sessionId);
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] evidenceId:", evidenceId);
 
         if (!sessionId || !evidenceId) {
-            log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Missing sessionId or evidenceId");
+            log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Missing sessionId or evidenceId");
             return NextResponse.json(
                 { error: "Session ID and Evidence ID are required" },
                 { status: 400 }
@@ -63,7 +65,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         if (typeof duration !== 'number' || duration < 0) {
-            log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Invalid duration:", duration);
+            log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Invalid duration:", duration);
             return NextResponse.json(
                 { error: "Valid duration is required" },
                 { status: 400 }
@@ -85,7 +87,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         });
 
         if (!evidence) {
-            log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Evidence not found");
+            log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Evidence not found");
             return NextResponse.json(
                 { error: "Evidence not found" },
                 { status: 404 }
@@ -93,7 +95,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         if (evidence.telemetryData.interviewSession.id !== sessionId) {
-            log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Evidence doesn't belong to session");
+            log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Evidence doesn't belong to session");
             return NextResponse.json(
                 { error: "Evidence doesn't belong to this session" },
                 { status: 403 }
@@ -101,7 +103,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         if (userId && evidence.telemetryData.interviewSession.candidateId !== userId) {
-            log.warn("[background-evidence/[evidenceId]/PATCH] ❌ Evidence doesn't belong to user");
+            log.warn(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ❌ Evidence doesn't belong to user");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 403 }
@@ -114,14 +116,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             data: { duration: Math.floor(duration) },
         });
 
-        log.info("[background-evidence/[evidenceId]/PATCH] ✅ Duration updated:", duration, "s");
+        log.info(LOG_CATEGORY, "[background-evidence/[evidenceId]/PATCH] ✅ Duration updated:", duration, "s");
 
         return NextResponse.json(
             { message: "Duration updated successfully", duration: Math.floor(duration) },
             { status: 200 }
         );
     } catch (error) {
-        log.error("❌ Error updating background evidence duration:", error);
+        log.error(LOG_CATEGORY, "❌ Error updating background evidence duration:", error);
         return NextResponse.json(
             { error: "Failed to update evidence duration" },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/background-evidence/route.ts
+++ b/app/api/interviews/session/[sessionId]/background-evidence/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -21,14 +23,14 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
  */
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[background-evidence/POST] ========== START ==========");
+        log.info(LOG_CATEGORY, "[background-evidence/POST] ========== START ==========");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("[background-evidence/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
-        log.info("[background-evidence/POST] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[background-evidence/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
+        log.info(LOG_CATEGORY, "[background-evidence/POST] Skip auth:", skipAuth);
 
         const body = await request.json();
         const { timestamp, questionText, answerText, questionNumber, userId: requestUserId } = body;
@@ -38,22 +40,22 @@ export async function POST(request: NextRequest, context: RouteContext) {
         if (skipAuth) {
             // In skip-auth mode, userId is optional. If not provided, we'll infer it from the session.
             userId = requestUserId || "";
-            log.info("[background-evidence/POST] Skip auth - User ID from request:", userId || "(not provided)");
+            log.info(LOG_CATEGORY, "[background-evidence/POST] Skip auth - User ID from request:", userId || "(not provided)");
         } else {
             if (!session?.user) {
-                log.warn("[background-evidence/POST] ❌ Unauthorized request");
+                log.warn(LOG_CATEGORY, "[background-evidence/POST] ❌ Unauthorized request");
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
             userId = (session.user as any).id;
-            log.info("[background-evidence/POST] ✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "[background-evidence/POST] ✅ User ID from session:", userId);
         }
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
-        log.info("[background-evidence/POST] sessionId:", sessionId);
+        log.info(LOG_CATEGORY, "[background-evidence/POST] sessionId:", sessionId);
 
         if (!sessionId) {
-            log.warn("[background-evidence/POST] ❌ Interview session id was not provided");
+            log.warn(LOG_CATEGORY, "[background-evidence/POST] ❌ Interview session id was not provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
@@ -62,7 +64,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
         // Validate required fields
         if (!timestamp || !questionText || typeof answerText !== 'string' || typeof questionNumber !== 'number') {
-            log.warn("[background-evidence/POST] ❌ Missing required fields:", { timestamp, questionText, answerText, questionNumber });
+            log.warn(LOG_CATEGORY, "[background-evidence/POST] ❌ Missing required fields:", { timestamp, questionText, answerText, questionNumber });
             return NextResponse.json(
                 { error: "Missing required fields: timestamp, questionText, answerText, questionNumber" },
                 { status: 400 }
@@ -70,7 +72,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Verify the interview session exists
-        log.info("[background-evidence/POST] Looking up interview session...");
+        log.info(LOG_CATEGORY, "[background-evidence/POST] Looking up interview session...");
         
         const whereClause: any = { id: sessionId };
         // Only filter by candidateId if we have a userId
@@ -86,22 +88,22 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.warn("[background-evidence/POST] ❌ Interview session not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "[background-evidence/POST] ❌ Interview session not found or doesn't belong to user");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
             );
         }
 
-        log.info("[background-evidence/POST] ✅ Interview session found:", interviewSession.id);
+        log.info(LOG_CATEGORY, "[background-evidence/POST] ✅ Interview session found:", interviewSession.id);
 
         // Get or create telemetry data
         let telemetryDataId: string;
         if (interviewSession.telemetryData) {
             telemetryDataId = interviewSession.telemetryData.id;
-            log.info("[background-evidence/POST] Using existing telemetryData:", telemetryDataId);
+            log.info(LOG_CATEGORY, "[background-evidence/POST] Using existing telemetryData:", telemetryDataId);
         } else {
-            log.info("[background-evidence/POST] Creating new telemetryData...");
+            log.info(LOG_CATEGORY, "[background-evidence/POST] Creating new telemetryData...");
             const telemetryData = await prisma.telemetryData.create({
                 data: {
                     interviewSessionId: sessionId,
@@ -111,17 +113,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
                 },
             });
             telemetryDataId = telemetryData.id;
-            log.info("[background-evidence/POST] ✅ Created telemetryData:", telemetryDataId);
+            log.info(LOG_CATEGORY, "[background-evidence/POST] ✅ Created telemetryData:", telemetryDataId);
         }
 
         const dateObj = new Date(timestamp);
         if (isNaN(dateObj.getTime())) {
-            log.error("[background-evidence/POST] ❌ Invalid timestamp:", timestamp);
+            log.error(LOG_CATEGORY, "[background-evidence/POST] ❌ Invalid timestamp:", timestamp);
             return NextResponse.json({ error: "Invalid timestamp" }, { status: 400 });
         }
 
         // Create background evidence record
-        log.info("[background-evidence/POST] Creating background evidence with data:", {
+        log.info(LOG_CATEGORY, "[background-evidence/POST] Creating background evidence with data:", {
             telemetryDataId,
             timestamp: dateObj.toISOString(),
             questionText: questionText.substring(0, 50) + "...",
@@ -130,7 +132,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!telemetryDataId) {
-            log.error("[background-evidence/POST] ❌ telemetryDataId is missing!");
+            log.error(LOG_CATEGORY, "[background-evidence/POST] ❌ telemetryDataId is missing!");
             return NextResponse.json({ error: "Internal Error: telemetryDataId missing" }, { status: 500 });
         }
 
@@ -146,7 +148,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-evidence/POST] ✅ Background evidence created successfully. ID:", backgroundEvidence.id);
+        log.info(LOG_CATEGORY, "[background-evidence/POST] ✅ Background evidence created successfully. ID:", backgroundEvidence.id);
 
         return NextResponse.json(
             {
@@ -156,7 +158,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             { status: 201 }
         );
     } catch (error) {
-        log.error("❌ Error creating background evidence:", error);
+        log.error(LOG_CATEGORY, "❌ Error creating background evidence:", error);
         return NextResponse.json(
             { error: "Failed to create background evidence" },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/background-summary/route.ts
+++ b/app/api/interviews/session/[sessionId]/background-summary/route.ts
@@ -11,6 +11,8 @@ import {
 } from "@/shared/prompts/backgroundSummaryPrompt";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -75,13 +77,13 @@ Write ONE short sentence summarizing this. MAX 10 WORDS. DO NOT EXCEED.`;
 // GET: Retrieve existing background summary
 export async function GET(request: NextRequest, context: RouteContext) {
     try {
-        log.info("Background summary retrieval API called");
+        log.info(LOG_CATEGORY, "Background summary retrieval API called");
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
 
         if (!sessionId) {
-            log.warn("❌ Interview session id was not provided");
+            log.warn(LOG_CATEGORY, "❌ Interview session id was not provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
@@ -103,7 +105,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.warn("❌ Interview session not found");
+            log.warn(LOG_CATEGORY, "❌ Interview session not found");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -113,7 +115,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
         const summary = interviewSession.telemetryData?.backgroundSummary;
 
         if (!summary) {
-            log.info("No background summary found for session");
+            log.info(LOG_CATEGORY, "No background summary found for session");
             return NextResponse.json(
                 { error: "Background summary not found" },
                 { status: 404 }
@@ -133,7 +135,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             },
         });
     } catch (error) {
-        log.error("❌ Error retrieving background summary:", error);
+        log.error(LOG_CATEGORY, "❌ Error retrieving background summary:", error);
         return NextResponse.json(
             { error: "Failed to retrieve background summary" },
             { status: 500 }
@@ -144,14 +146,14 @@ export async function GET(request: NextRequest, context: RouteContext) {
 // POST: Generate background summary
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[background-summary/POST] ========== START ==========");
+        log.info(LOG_CATEGORY, "[background-summary/POST] ========== START ==========");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("[background-summary/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
-        log.info("[background-summary/POST] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[background-summary/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Skip auth:", skipAuth);
 
         const body = await request.json();
         const { scores, rationales, companyName, roleName, userId: requestUserId } = body;
@@ -160,31 +162,31 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
         if (skipAuth) {
             if (!requestUserId) {
-                log.warn("[background-summary/POST] ❌ skip-auth mode but no userId provided in request");
+                log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ skip-auth mode but no userId provided in request");
                 return NextResponse.json(
                     { error: "userId required when skip-auth=true" },
                     { status: 400 }
                 );
             }
             userId = requestUserId;
-            log.info("[background-summary/POST] ✅ Skip auth - User ID from request:", userId);
+            log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Skip auth - User ID from request:", userId);
         } else {
             if (!session?.user) {
-                log.warn("[background-summary/POST] ❌ Unauthorized request");
+                log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ Unauthorized request");
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
             userId = (session.user as any).id;
-            log.info("[background-summary/POST] ✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "[background-summary/POST] ✅ User ID from session:", userId);
         }
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
-        log.info("[background-summary/POST] userId:", userId);
-        log.info("[background-summary/POST] sessionId (raw):", rawSessionId);
-        log.info("[background-summary/POST] sessionId (normalized):", sessionId);
+        log.info(LOG_CATEGORY, "[background-summary/POST] userId:", userId);
+        log.info(LOG_CATEGORY, "[background-summary/POST] sessionId (raw):", rawSessionId);
+        log.info(LOG_CATEGORY, "[background-summary/POST] sessionId (normalized):", sessionId);
 
         if (!sessionId) {
-            log.warn("[background-summary/POST] ❌ Interview session id was not provided");
+            log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ Interview session id was not provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
@@ -192,7 +194,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Verify the interview session exists and belongs to the user
-        log.info("[background-summary/POST] Looking up interview session...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Looking up interview session...");
         const interviewSession = await prisma.interviewSession.findFirst({
             where: {
                 id: sessionId,
@@ -217,21 +219,21 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.warn("[background-summary/POST] ❌ Interview session not found or doesn't belong to user");
-            log.warn("[background-summary/POST] Searched for: sessionId=", sessionId, "candidateId=", userId);
+            log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ Interview session not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "[background-summary/POST] Searched for: sessionId=", sessionId, "candidateId=", userId);
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
             );
         }
 
-        log.info("[background-summary/POST] ✅ Interview session found:", interviewSession.id);
-        log.info("[background-summary/POST] Has telemetryData:", !!interviewSession.telemetryData);
-        log.info("[background-summary/POST] Has backgroundSummary:", !!interviewSession.telemetryData?.backgroundSummary);
+        log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Interview session found:", interviewSession.id);
+        log.info(LOG_CATEGORY, "[background-summary/POST] Has telemetryData:", !!interviewSession.telemetryData);
+        log.info(LOG_CATEGORY, "[background-summary/POST] Has backgroundSummary:", !!interviewSession.telemetryData?.backgroundSummary);
 
         // Check if summary already exists
         if (interviewSession.telemetryData?.backgroundSummary) {
-            log.info("[background-summary/POST] ⚠️ Background summary already exists for session, skipping generation");
+            log.info(LOG_CATEGORY, "[background-summary/POST] ⚠️ Background summary already exists for session, skipping generation");
             return NextResponse.json(
                 { message: "Background summary already exists" },
                 { status: 200 }
@@ -240,32 +242,32 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
         // Ensure telemetry data exists
         if (!interviewSession.telemetryData) {
-            log.warn("[background-summary/POST] ❌ No telemetry data found for session");
+            log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ No telemetry data found for session");
             return NextResponse.json(
                 { error: "Telemetry data not found" },
                 { status: 404 }
             );
         }
 
-        log.info("[background-summary/POST] TelemetryData ID:", interviewSession.telemetryData.id);
+        log.info(LOG_CATEGORY, "[background-summary/POST] TelemetryData ID:", interviewSession.telemetryData.id);
 
-        log.info("[background-summary/POST] Request body:", { scores, rationales, companyName, roleName });
+        log.info(LOG_CATEGORY, "[background-summary/POST] Request body:", { scores, rationales, companyName, roleName });
 
         // Get experience categories from job
         const experienceCategoryDefinitions = (interviewSession.application.job.experienceCategories as any) || [];
         
         if (!experienceCategoryDefinitions || experienceCategoryDefinitions.length === 0) {
-            log.error("[background-summary/POST] ❌ No experience categories defined for job");
+            log.error(LOG_CATEGORY, "[background-summary/POST] ❌ No experience categories defined for job");
             return NextResponse.json(
                 { error: "Job must have experience categories defined" },
                 { status: 400 }
             );
         }
 
-        log.info("[background-summary/POST] Experience categories:", experienceCategoryDefinitions.map((c: any) => c.name).join(', '));
+        log.info(LOG_CATEGORY, "[background-summary/POST] Experience categories:", experienceCategoryDefinitions.map((c: any) => c.name).join(', '));
 
         // Fetch background messages
-        log.info("[background-summary/POST] Fetching conversation messages...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Fetching conversation messages...");
         const messages = await prisma.conversationMessage.findMany({
             where: {
                 interviewSessionId: sessionId,
@@ -276,17 +278,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-summary/POST] Found", messages.length, "background messages");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Found", messages.length, "background messages");
 
         if (messages.length === 0) {
-            log.warn("[background-summary/POST] ❌ No background messages found in DB");
+            log.warn(LOG_CATEGORY, "[background-summary/POST] ❌ No background messages found in DB");
             return NextResponse.json(
                 { error: "No background conversation found" },
                 { status: 400 }
             );
         }
 
-        log.info(`[background-summary/POST] Generating summary from ${messages.length} messages...`);
+        log.info(LOG_CATEGORY, `[background-summary/POST] Generating summary from ${messages.length} messages...`);
 
         // Build prompt
         const prompt = buildBackgroundSummaryPrompt({
@@ -304,17 +306,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         // Call OpenAI
-        log.info("[background-summary/POST] Checking OpenAI API key...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Checking OpenAI API key...");
         const openaiApiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
         if (!openaiApiKey) {
-            log.error("[background-summary/POST] ❌ OpenAI API key not configured");
+            log.error(LOG_CATEGORY, "[background-summary/POST] ❌ OpenAI API key not configured");
             return NextResponse.json(
                 { error: "OpenAI API key not configured" },
                 { status: 500 }
             );
         }
 
-        log.info("[background-summary/POST] Calling OpenAI with model:", SUMMARY_MODEL, "temperature:", SUMMARY_TEMPERATURE);
+        log.info(LOG_CATEGORY, "[background-summary/POST] Calling OpenAI with model:", SUMMARY_MODEL, "temperature:", SUMMARY_TEMPERATURE);
         const openai = new OpenAI({ apiKey: openaiApiKey });
 
         const completion = await openai.chat.completions.create({
@@ -329,17 +331,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         const responseText = completion.choices[0]?.message?.content;
-        log.info("[background-summary/POST] OpenAI response length:", responseText?.length || 0);
+        log.info(LOG_CATEGORY, "[background-summary/POST] OpenAI response length:", responseText?.length || 0);
         
         if (!responseText) {
-            log.error("[background-summary/POST] ❌ Empty response from OpenAI");
+            log.error(LOG_CATEGORY, "[background-summary/POST] ❌ Empty response from OpenAI");
             return NextResponse.json(
                 { error: "Failed to generate summary" },
                 { status: 500 }
             );
         }
 
-        log.info("[background-summary/POST] Parsing OpenAI response...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Parsing OpenAI response...");
 
         // Strip markdown code block wrapper if present
         let cleanedResponse = responseText.trim();
@@ -353,11 +355,11 @@ export async function POST(request: NextRequest, context: RouteContext) {
         let summaryData: SummaryOutput;
         try {
             summaryData = JSON.parse(cleanedResponse);
-            log.info("[background-summary/POST] ✅ Successfully parsed summary JSON");
+            log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Successfully parsed summary JSON");
         } catch (parseError) {
-            log.error("[background-summary/POST] ❌ Failed to parse OpenAI response:", parseError);
-            log.error("[background-summary/POST] Original response:", responseText.substring(0, 500));
-            log.error("[background-summary/POST] Cleaned response:", cleanedResponse.substring(0, 500));
+            log.error(LOG_CATEGORY, "[background-summary/POST] ❌ Failed to parse OpenAI response:", parseError);
+            log.error(LOG_CATEGORY, "[background-summary/POST] Original response:", responseText.substring(0, 500));
+            log.error(LOG_CATEGORY, "[background-summary/POST] Cleaned response:", cleanedResponse.substring(0, 500));
             return NextResponse.json(
                 { error: "Failed to parse summary response" },
                 { status: 500 }
@@ -365,7 +367,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Store in database
-        log.info("[background-summary/POST] Saving summary to database...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Saving summary to database...");
         
         // Aggregate category contributions (simple averaging)
         const contributions = await prisma.categoryContribution.findMany({
@@ -405,7 +407,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             const confidence = Math.min(1.0, contribs.length / TARGET_CONTRIBUTIONS);
             const adjustedScore = Math.round(rawAverage * confidence);
             
-            log.info(`[background-summary/POST] ${categoryName}: ${contribs.length} contributions, raw avg=${Math.round(rawAverage)}, confidence=${confidence.toFixed(2)}, adjusted=${adjustedScore}`);
+            log.info(LOG_CATEGORY, `[background-summary/POST] ${categoryName}: ${contribs.length} contributions, raw avg=${Math.round(rawAverage)}, confidence=${confidence.toFixed(2)}, adjusted=${adjustedScore}`);
             
             const categoryDef = experienceCategoryDefinitions?.find(c => c.name === categoryName);
             
@@ -446,7 +448,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             };
         }
 
-        log.info("[background-summary/POST] Aggregated experience categories:", Object.keys(experienceCategories));
+        log.info(LOG_CATEGORY, "[background-summary/POST] Aggregated experience categories:", Object.keys(experienceCategories));
         
         const summaryDbData = {
             executiveSummary: summaryData.executiveSummary,
@@ -472,20 +474,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-summary/POST] ✅ Background summary created successfully. ID:", backgroundSummary.id);
+        log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Background summary created successfully. ID:", backgroundSummary.id);
 
         // Create EvidenceClip records for each trait's evidence
-        log.info("[background-summary/POST] Creating evidence clips...");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Creating evidence clips...");
         
         // Log what OpenAI gave us for evidence
-        log.info("[background-summary/POST] OpenAI Evidence Summary:");
+        log.info(LOG_CATEGORY, "[background-summary/POST] OpenAI Evidence Summary:");
         if (summaryData.experienceCategories) {
             for (const [categoryName, categoryData] of Object.entries(summaryData.experienceCategories)) {
                 const evidence = (categoryData as any).evidence;
                 if (evidence && Array.isArray(evidence)) {
-                    log.info(`  - ${categoryName} evidence count:`, evidence.length);
+                    log.info(LOG_CATEGORY, `  - ${categoryName} evidence count:`, evidence.length);
                     evidence.forEach((ev: any, idx: number) => {
-                        log.info(`  - ${categoryName}[${idx}]: question="${ev.question?.substring(0, 50)}...", hasReasoning=${!!ev.reasoning}, hasAnswerExcerpt=${!!ev.answerExcerpt}`);
+                        log.info(LOG_CATEGORY, `  - ${categoryName}[${idx}]: question="${ev.question?.substring(0, 50)}...", hasReasoning=${!!ev.reasoning}, hasAnswerExcerpt=${!!ev.answerExcerpt}`);
                     });
                 }
             }
@@ -501,7 +503,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[background-summary/POST] Found", backgroundEvidenceRecords.length, "background evidence records");
+        log.info(LOG_CATEGORY, "[background-summary/POST] Found", backgroundEvidenceRecords.length, "background evidence records");
 
         /**
          * Selects the most relevant trait evidence for a background record, preferring
@@ -574,7 +576,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
                     (record.timestamp.getTime() - recordingStart.getTime()) / 1000
                 );
                 
-                log.info(`[background-summary/POST] ${categoryName}[${index}]: Matching record Q="${record.questionText.substring(0, 50)}..." with evidence:`, {
+                log.info(LOG_CATEGORY, `[background-summary/POST] ${categoryName}[${index}]: Matching record Q="${record.questionText.substring(0, 50)}..." with evidence:`, {
                     matched: categoryEvidence ? `"${categoryEvidence.question.substring(0, 50)}..."` : 'null',
                     hasReasoning: categoryEvidence?.reasoning ? true : false,
                     hasAnswerExcerpt: categoryEvidence?.answerExcerpt ? true : false,
@@ -591,7 +593,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
                 
                 const description = buildClipDescription(categoryEvidence, record, categoryName);
                 
-                log.info(`[background-summary/POST] ${categoryName}[${index}]: Using description="${description.substring(0, 100)}..."`);
+                log.info(LOG_CATEGORY, `[background-summary/POST] ${categoryName}[${index}]: Using description="${description.substring(0, 100)}..."`);
 
                 await prisma.evidenceClip.create({
                     data: {
@@ -608,7 +610,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
                     },
                 });
 
-                log.info(`[background-summary/POST] ✅ Created ${categoryName} evidence clip at ${startTimeSeconds}s with duration ${clipDuration}s`);
+                log.info(LOG_CATEGORY, `[background-summary/POST] ✅ Created ${categoryName} evidence clip at ${startTimeSeconds}s with duration ${clipDuration}s`);
             }
         };
 
@@ -621,8 +623,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
             }
         }
 
-        log.info("[background-summary/POST] ✅ Evidence clips created successfully");
-        log.info("[background-summary/POST] ✅ Short captions already generated in evidenceLinks");
+        log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Evidence clips created successfully");
+        log.info(LOG_CATEGORY, "[background-summary/POST] ✅ Short captions already generated in evidenceLinks");
 
         return NextResponse.json(
             {
@@ -632,7 +634,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             { status: 202 }
         );
     } catch (error) {
-        log.error("❌ Error generating background summary:", error);
+        log.error(LOG_CATEGORY, "❌ Error generating background summary:", error);
         return NextResponse.json(
             { error: "Failed to generate background summary" },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/code-quality-analysis/route.ts
+++ b/app/api/interviews/session/[sessionId]/code-quality-analysis/route.ts
@@ -3,6 +3,8 @@ import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 import OpenAI from "openai";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId: string }>;
 };
@@ -11,7 +13,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     try {
         const { sessionId } = await context.params;
         
-        log.info("[Code Quality Analysis GET] Fetching analysis for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Code Quality Analysis GET] Fetching analysis for session:", sessionId);
 
         // Fetch session with coding summary
         const session = await prisma.interviewSession.findUnique({
@@ -61,7 +63,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             finalCode: codingSummary.finalCode,
         });
     } catch (error: any) {
-        log.error("[Code Quality Analysis GET] Error:", error);
+        log.error(LOG_CATEGORY, "[Code Quality Analysis GET] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to fetch code quality analysis",
@@ -76,7 +78,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     try {
         const openaiApiKey = process.env.NEXT_PUBLIC_OPENAI_API_KEY || process.env.OPENAI_API_KEY;
         if (!openaiApiKey) {
-            log.error("[Code Quality Analysis] OpenAI API key not configured");
+            log.error(LOG_CATEGORY, "[Code Quality Analysis] OpenAI API key not configured");
             return NextResponse.json(
                 { error: "OpenAI API key not configured" },
                 { status: 500 }
@@ -87,7 +89,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         
         const { sessionId } = await context.params;
         
-        log.info("[Code Quality Analysis] Starting analysis for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Code Quality Analysis] Starting analysis for session:", sessionId);
 
         // Fetch session with coding summary
         const session = await prisma.interviewSession.findUnique({
@@ -178,7 +180,7 @@ ${finalCode}
 
 Provide a detailed code quality analysis with specific line numbers and code segments.`;
 
-        log.info("[Code Quality Analysis] Calling OpenAI...");
+        log.info(LOG_CATEGORY, "[Code Quality Analysis] Calling OpenAI...");
 
         const completion = await openaiClient.chat.completions.create({
             model: "gpt-4o",
@@ -195,11 +197,11 @@ Provide a detailed code quality analysis with specific line numbers and code seg
             throw new Error("No response from OpenAI");
         }
 
-        log.info("[Code Quality Analysis] OpenAI response received");
+        log.info(LOG_CATEGORY, "[Code Quality Analysis] OpenAI response received");
 
         const analysis = JSON.parse(responseText);
 
-        log.info("[Code Quality Analysis] Parsed analysis, saving to database...");
+        log.info(LOG_CATEGORY, "[Code Quality Analysis] Parsed analysis, saving to database...");
 
         // Update the coding summary with the analysis
         await prisma.codingSummary.update({
@@ -209,14 +211,14 @@ Provide a detailed code quality analysis with specific line numbers and code seg
             },
         });
 
-        log.info("[Code Quality Analysis] Analysis saved to database");
+        log.info(LOG_CATEGORY, "[Code Quality Analysis] Analysis saved to database");
 
         return NextResponse.json({
             message: "Code quality analysis generated and saved successfully",
             analysis,
         });
     } catch (error: any) {
-        log.error("[Code Quality Analysis] Error:", error);
+        log.error(LOG_CATEGORY, "[Code Quality Analysis] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to generate code quality analysis",

--- a/app/api/interviews/session/[sessionId]/coding-summary-update/route.ts
+++ b/app/api/interviews/session/[sessionId]/coding-summary-update/route.ts
@@ -3,6 +3,8 @@ import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 import { calculateScore, type RawScores, type WorkstyleMetrics } from "app/shared/utils/calculateScore";
 
+const LOG_CATEGORY = "interviews";
+
 export async function PATCH(
     request: NextRequest,
     { params }: { params: { sessionId: string } }
@@ -19,7 +21,7 @@ export async function PATCH(
             );
         }
 
-        log.info("[Coding Summary Update] Updating job-specific categories for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Coding Summary Update] Updating job-specific categories for session:", sessionId);
 
         // Find coding summary via session
         const session = await prisma.interviewSession.findUnique({
@@ -56,7 +58,7 @@ export async function PATCH(
             orderBy: { timestamp: "asc" }
         });
 
-        log.info(`[Coding Summary Update] Found ${allContributions.length} real-time contributions`);
+        log.info(LOG_CATEGORY, `[Coding Summary Update] Found ${allContributions.length} real-time contributions`);
 
         // Group contributions by category
         const categoriesByName = new Map<string, any[]>();
@@ -91,7 +93,7 @@ export async function PATCH(
                 const confidence = Math.min(1.0, contributions.length / TARGET_CONTRIBUTIONS);
                 const adjustedScore = Math.round(rawAverage * confidence);
                 
-                log.info(`[Coding Summary Update] ${categoryName}: ${contributions.length} contributions, raw avg=${Math.round(rawAverage)}, confidence=${confidence.toFixed(2)}, adjusted=${adjustedScore}, final override=${categoryData.score}`);
+                log.info(LOG_CATEGORY, `[Coding Summary Update] ${categoryName}: ${contributions.length} contributions, raw avg=${Math.round(rawAverage)}, confidence=${confidence.toFixed(2)}, adjusted=${adjustedScore}, final override=${categoryData.score}`);
                 
                 // Use final evaluation score (overrides contribution-adjusted score)
                 enrichedCategories[categoryName] = {
@@ -119,7 +121,7 @@ export async function PATCH(
                     contributions: []
                 };
                 
-                log.info(`[Coding Summary Update] ${categoryName}: No contributions, using final evaluation score=${categoryData.score}`);
+                log.info(LOG_CATEGORY, `[Coding Summary Update] ${categoryName}: No contributions, using final evaluation score=${categoryData.score}`);
             }
         }
 
@@ -131,7 +133,7 @@ export async function PATCH(
             },
         });
 
-        log.info("[Coding Summary Update] Successfully updated job-specific categories with contribution data");
+        log.info(LOG_CATEGORY, "[Coding Summary Update] Successfully updated job-specific categories with contribution data");
 
         // Calculate and persist final score
         let finalScore: number | null = null;
@@ -185,9 +187,9 @@ export async function PATCH(
                     data: { finalScore },
                 });
 
-                log.info(`[Coding Summary Update] Calculated and saved finalScore=${finalScore} for session ${sessionId}`);
+                log.info(LOG_CATEGORY, `[Coding Summary Update] Calculated and saved finalScore=${finalScore} for session ${sessionId}`);
             } catch (error) {
-                log.error("[Coding Summary Update] Score calculation error:", error);
+                log.error(LOG_CATEGORY, "[Coding Summary Update] Score calculation error:", error);
             }
         }
 
@@ -197,7 +199,7 @@ export async function PATCH(
             finalScore,
         });
     } catch (error: any) {
-        log.error("[Coding Summary Update] Error:", error);
+        log.error(LOG_CATEGORY, "[Coding Summary Update] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to update coding summary",

--- a/app/api/interviews/session/[sessionId]/coding-summary/route.ts
+++ b/app/api/interviews/session/[sessionId]/coding-summary/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 export async function GET(
     _request: NextRequest,
     { params }: { params: Promise<{ sessionId: string }> }
@@ -9,7 +11,7 @@ export async function GET(
     try {
         const { sessionId } = await params;
 
-        log.info("[Coding Summary API] Fetching summary for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Coding Summary API] Fetching summary for session:", sessionId);
 
         // Get session with telemetry data and coding summary
         const session = await prisma.interviewSession.findUnique({
@@ -58,7 +60,7 @@ export async function GET(
 
         return NextResponse.json(response);
     } catch (error: any) {
-        log.error("[Coding Summary API] Error:", error);
+        log.error(LOG_CATEGORY, "[Coding Summary API] Error:", error);
         return NextResponse.json(
             {
                 error: "Failed to fetch coding summary",

--- a/app/api/interviews/session/[sessionId]/contributions/route.ts
+++ b/app/api/interviews/session/[sessionId]/contributions/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "lib/prisma";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId: string }>;
 };
@@ -65,7 +67,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             };
         });
 
-        log.info(`[contributions/GET] Fetched ${contributions.length} contributions for ${jobCategories.length} categories`);
+        log.info(LOG_CATEGORY, `[contributions/GET] Fetched ${contributions.length} contributions for ${jobCategories.length} categories`);
 
         return NextResponse.json({
             contributions,
@@ -73,7 +75,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             byCategory,
         });
     } catch (error: any) {
-        log.error("[contributions/GET] Error fetching contributions:", error);
+        log.error(LOG_CATEGORY, "[contributions/GET] Error fetching contributions:", error);
         return NextResponse.json(
             { error: "Failed to fetch contributions", details: error.message },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/external-tools/route.ts
+++ b/app/api/interviews/session/[sessionId]/external-tools/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -30,7 +32,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         const body = await request.json();
-        log.info("[External Tools API] POST request body:", body);
+        log.info(LOG_CATEGORY, "[External Tools API] POST request body:", body);
 
         const {
             timestamp,
@@ -79,7 +81,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             );
         }
 
-        log.info("[External Tools API] Creating external tool usage record...");
+        log.info(LOG_CATEGORY, "[External Tools API] Creating external tool usage record...");
 
         // Create the external tool usage record
         const externalToolUsage = await prisma.externalToolUsage.create({
@@ -98,7 +100,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[External Tools API] External tool usage created:", externalToolUsage.id);
+        log.info(LOG_CATEGORY, "[External Tools API] External tool usage created:", externalToolUsage.id);
 
         // Update WorkstyleMetrics.externalToolUsage counter
         const session = await prisma.interviewSession.findUnique({
@@ -121,7 +123,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
                     },
                 },
             });
-            log.info("[External Tools API] WorkstyleMetrics.externalToolUsage incremented");
+            log.info(LOG_CATEGORY, "[External Tools API] WorkstyleMetrics.externalToolUsage incremented");
         }
 
         // Note: VideoChapter creation moved to /paste-chapter endpoint (called at paste detection)
@@ -131,7 +133,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             id: externalToolUsage.id,
         });
     } catch (error: any) {
-        log.error("[External Tools API] Error creating external tool usage:", error);
+        log.error(LOG_CATEGORY, "[External Tools API] Error creating external tool usage:", error);
         return NextResponse.json(
             {
                 error: "Failed to record external tool usage",
@@ -158,7 +160,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             );
         }
 
-        log.info("[External Tools API] Fetching external tool usages for session:", sessionId);
+        log.info(LOG_CATEGORY, "[External Tools API] Fetching external tool usages for session:", sessionId);
 
         const externalToolUsages = await prisma.externalToolUsage.findMany({
             where: {
@@ -169,11 +171,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[External Tools API] Found external tool usages:", externalToolUsages.length);
+        log.info(LOG_CATEGORY, "[External Tools API] Found external tool usages:", externalToolUsages.length);
 
         return NextResponse.json(externalToolUsages);
     } catch (error: any) {
-        log.error("[External Tools API] Error fetching external tool usages:", error);
+        log.error(LOG_CATEGORY, "[External Tools API] Error fetching external tool usages:", error);
         return NextResponse.json(
             {
                 error: "Failed to fetch external tool usages",

--- a/app/api/interviews/session/[sessionId]/messages/route.ts
+++ b/app/api/interviews/session/[sessionId]/messages/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -17,14 +19,14 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
 
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[messages/POST] ========== START ==========");
+        log.info(LOG_CATEGORY, "[messages/POST] ========== START ==========");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("[messages/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
-        log.info("[messages/POST] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[messages/POST] Session:", session ? `Found (user: ${(session.user as any)?.email})` : "Not found");
+        log.info(LOG_CATEGORY, "[messages/POST] Skip auth:", skipAuth);
 
         const body = await request.json();
         const { messages, userId: requestUserId } = body;
@@ -33,31 +35,31 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
         if (skipAuth) {
             if (!requestUserId) {
-                log.warn("[messages/POST] ❌ skip-auth mode but no userId provided in request");
+                log.warn(LOG_CATEGORY, "[messages/POST] ❌ skip-auth mode but no userId provided in request");
                 return NextResponse.json(
                     { error: "userId required when skip-auth=true" },
                     { status: 400 }
                 );
             }
             userId = requestUserId;
-            log.info("[messages/POST] ✅ Skip auth - User ID from request:", userId);
+            log.info(LOG_CATEGORY, "[messages/POST] ✅ Skip auth - User ID from request:", userId);
         } else {
             if (!session?.user) {
-                log.warn("[messages/POST] ❌ Unauthorized request");
+                log.warn(LOG_CATEGORY, "[messages/POST] ❌ Unauthorized request");
                 return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
             }
             userId = (session.user as any).id;
-            log.info("[messages/POST] ✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "[messages/POST] ✅ User ID from session:", userId);
         }
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
-        log.info("[messages/POST] userId:", userId);
-        log.info("[messages/POST] sessionId (raw):", rawSessionId);
-        log.info("[messages/POST] sessionId (normalized):", sessionId);
+        log.info(LOG_CATEGORY, "[messages/POST] userId:", userId);
+        log.info(LOG_CATEGORY, "[messages/POST] sessionId (raw):", rawSessionId);
+        log.info(LOG_CATEGORY, "[messages/POST] sessionId (normalized):", sessionId);
 
         if (!sessionId) {
-            log.warn("[messages/POST] ❌ Interview session id was not provided");
+            log.warn(LOG_CATEGORY, "[messages/POST] ❌ Interview session id was not provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
@@ -65,7 +67,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         // Verify the interview session exists and belongs to the user
-        log.info("[messages/POST] Looking up interview session...");
+        log.info(LOG_CATEGORY, "[messages/POST] Looking up interview session...");
         const interviewSession = await prisma.interviewSession.findFirst({
             where: {
                 id: sessionId,
@@ -74,20 +76,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.warn("[messages/POST] ❌ Interview session not found or doesn't belong to user");
-            log.warn("[messages/POST] Searched for: sessionId=", sessionId, "candidateId=", userId);
+            log.warn(LOG_CATEGORY, "[messages/POST] ❌ Interview session not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "[messages/POST] Searched for: sessionId=", sessionId, "candidateId=", userId);
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
             );
         }
 
-        log.info("[messages/POST] ✅ Interview session found:", interviewSession.id);
+        log.info(LOG_CATEGORY, "[messages/POST] ✅ Interview session found:", interviewSession.id);
 
-        log.info("[messages/POST] Received messages:", messages?.length || 0);
+        log.info(LOG_CATEGORY, "[messages/POST] Received messages:", messages?.length || 0);
 
         if (!Array.isArray(messages)) {
-            log.warn("[messages/POST] ❌ Invalid messages format (not an array)");
+            log.warn(LOG_CATEGORY, "[messages/POST] ❌ Invalid messages format (not an array)");
             return NextResponse.json(
                 { error: "Messages must be an array" },
                 { status: 400 }
@@ -95,15 +97,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
         }
 
         if (messages.length === 0) {
-            log.warn("[messages/POST] ⚠️ Empty messages array received");
+            log.warn(LOG_CATEGORY, "[messages/POST] ⚠️ Empty messages array received");
             return NextResponse.json({
                 message: "No messages to save",
                 count: 0,
             });
         }
 
-        log.info(`[messages/POST] Saving ${messages.length} messages for session ${sessionId}...`);
-        log.info("[messages/POST] First message sample:", messages[0]);
+        log.info(LOG_CATEGORY, `[messages/POST] Saving ${messages.length} messages for session ${sessionId}...`);
+        log.info(LOG_CATEGORY, "[messages/POST] First message sample:", messages[0]);
 
         // Batch create messages in transaction
         await prisma.$transaction(
@@ -120,15 +122,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
             )
         );
 
-        log.info("[messages/POST] ✅ Messages saved successfully. Count:", messages.length);
+        log.info(LOG_CATEGORY, "[messages/POST] ✅ Messages saved successfully. Count:", messages.length);
 
         return NextResponse.json({
             message: "Messages saved successfully",
             count: messages.length,
         });
     } catch (error) {
-        log.error("[messages/POST] ❌ Error saving messages:", error);
-        log.error("[messages/POST] Error stack:", error instanceof Error ? error.stack : "N/A");
+        log.error(LOG_CATEGORY, "[messages/POST] ❌ Error saving messages:", error);
+        log.error(LOG_CATEGORY, "[messages/POST] Error stack:", error instanceof Error ? error.stack : "N/A");
         return NextResponse.json(
             { error: "Failed to save messages" },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/paste-chapter/route.ts
+++ b/app/api/interviews/session/[sessionId]/paste-chapter/route.ts
@@ -3,6 +3,8 @@ import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 import { createVideoChapter } from "../../../shared/createVideoChapter";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -40,7 +42,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             );
         }
 
-        log.info("[Paste Chapter API] Creating chapter at paste detection");
+        log.info(LOG_CATEGORY, "[Paste Chapter API] Creating chapter at paste detection");
 
         const session = await prisma.interviewSession.findUnique({
             where: { id: sessionId },
@@ -64,10 +66,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
         const recordingStartTime = session.recordingStartedAt;
         const videoOffset = Math.floor((pasteTimestamp.getTime() - recordingStartTime.getTime()) / 1000);
         
-        log.info("🎬 [Paste Chapter API] VideoChapter calculation:");
-        log.info("  - Recording started at:", recordingStartTime.toISOString());
-        log.info("  - Paste occurred at:", pasteTimestamp.toISOString());
-        log.info("  - Calculated video offset (s):", videoOffset);
+        log.info(LOG_CATEGORY, "🎬 [Paste Chapter API] VideoChapter calculation:");
+        log.info(LOG_CATEGORY, "  - Recording started at:", recordingStartTime.toISOString());
+        log.info(LOG_CATEGORY, "  - Paste occurred at:", pasteTimestamp.toISOString());
+        log.info(LOG_CATEGORY, "  - Calculated video offset (s):", videoOffset);
         
         if (videoOffset < 0) {
             return NextResponse.json(
@@ -89,7 +91,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             chapterId: videoChapter.id,
         });
     } catch (error: any) {
-        log.error("[Paste Chapter API] Error creating chapter:", error);
+        log.error(LOG_CATEGORY, "[Paste Chapter API] Error creating chapter:", error);
         return NextResponse.json(
             {
                 error: "Failed to create chapter",

--- a/app/api/interviews/session/[sessionId]/route.ts
+++ b/app/api/interviews/session/[sessionId]/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -17,31 +19,31 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
 
 export async function GET(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[Session GET] === FETCH REQUEST RECEIVED ===");
+        log.info(LOG_CATEGORY, "[Session GET] === FETCH REQUEST RECEIVED ===");
         
         const skipAuth = request.nextUrl.searchParams.get("skip-auth") === "true";
         const shouldSkipAuth = skipAuth;
         
-        log.info("[Session GET] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[Session GET] Skip auth:", skipAuth);
 
         const session = await getServerSession(authOptions);
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
 
         if (!sessionId) {
-            log.error("[Session GET] ❌ No session ID provided");
+            log.error(LOG_CATEGORY, "[Session GET] ❌ No session ID provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
             );
         }
 
-        log.info("[Session GET] Session ID:", sessionId);
+        log.info(LOG_CATEGORY, "[Session GET] Session ID:", sessionId);
 
         const userId = shouldSkipAuth ? null : (session?.user as any)?.id;
         
         if (!shouldSkipAuth && !userId) {
-            log.error("[Session GET] ❌ No user ID found and not in skip-auth/demo mode");
+            log.error(LOG_CATEGORY, "[Session GET] ❌ No user ID found and not in skip-auth/demo mode");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -56,14 +58,14 @@ export async function GET(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.error("[Session GET] ❌ Interview session not found");
+            log.error(LOG_CATEGORY, "[Session GET] ❌ Interview session not found");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
             );
         }
 
-        log.info("[Session GET] ✅ Session found:", {
+        log.info(LOG_CATEGORY, "[Session GET] ✅ Session found:", {
             id: interviewSession.id,
             recordingStartedAt: interviewSession.recordingStartedAt,
         });
@@ -72,7 +74,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
             interviewSession,
         });
     } catch (error) {
-        log.error("[Session GET] ❌ ERROR:", error);
+        log.error(LOG_CATEGORY, "[Session GET] ❌ ERROR:", error);
         return NextResponse.json(
             { error: "Failed to fetch interview session" },
             { status: 500 }
@@ -82,42 +84,42 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[Session PATCH] === UPDATE REQUEST RECEIVED ===");
-        log.info("[Session PATCH] URL:", request.url);
+        log.info(LOG_CATEGORY, "[Session PATCH] === UPDATE REQUEST RECEIVED ===");
+        log.info(LOG_CATEGORY, "[Session PATCH] URL:", request.url);
 
         const skipAuth = request.nextUrl.searchParams.get("skip-auth") === "true";
         const shouldSkipAuth = skipAuth;
         
-        log.info("[Session PATCH] Skip auth:", skipAuth);
-        log.info("[Session PATCH] Should skip auth:", shouldSkipAuth);
+        log.info(LOG_CATEGORY, "[Session PATCH] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[Session PATCH] Should skip auth:", shouldSkipAuth);
 
         const session = await getServerSession(authOptions);
-        log.info("[Session PATCH] Auth session:", session ? "found" : "not found");
-        log.info("[Session PATCH] User ID:", (session?.user as any)?.id);
+        log.info(LOG_CATEGORY, "[Session PATCH] Auth session:", session ? "found" : "not found");
+        log.info(LOG_CATEGORY, "[Session PATCH] User ID:", (session?.user as any)?.id);
 
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
 
         if (!sessionId) {
-            log.error("[Session PATCH] ❌ No session ID provided");
+            log.error(LOG_CATEGORY, "[Session PATCH] ❌ No session ID provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
             );
         }
 
-        log.info("[Session PATCH] Session ID:", sessionId);
+        log.info(LOG_CATEGORY, "[Session PATCH] Session ID:", sessionId);
 
         // Verify the interview session exists (and belongs to user if not demo mode)
         const userId = shouldSkipAuth ? null : (session?.user as any)?.id;
         
-        log.info("[Session PATCH] Querying session with where clause:", {
+        log.info(LOG_CATEGORY, "[Session PATCH] Querying session with where clause:", {
             id: sessionId,
             candidateId: shouldSkipAuth ? "(skipped)" : userId,
         });
         
         if (!shouldSkipAuth && !userId) {
-            log.error("[Session PATCH] ❌ No user ID found and not in skip-auth/demo mode");
+            log.error(LOG_CATEGORY, "[Session PATCH] ❌ No user ID found and not in skip-auth/demo mode");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -131,9 +133,9 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[Session PATCH] Session found:", interviewSession ? "YES" : "NO");
+        log.info(LOG_CATEGORY, "[Session PATCH] Session found:", interviewSession ? "YES" : "NO");
         if (interviewSession) {
-            log.info("[Session PATCH] Current session state:", {
+            log.info(LOG_CATEGORY, "[Session PATCH] Current session state:", {
                 id: interviewSession.id,
                 candidateId: interviewSession.candidateId,
                 videoUrl: interviewSession.videoUrl,
@@ -142,7 +144,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         if (!interviewSession) {
-            log.error("[Session PATCH] ❌ Interview session not found or doesn't belong to user");
+            log.error(LOG_CATEGORY, "[Session PATCH] ❌ Interview session not found or doesn't belong to user");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -150,7 +152,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         const body = await request.json();
-        log.info("[Session PATCH] Request body:", JSON.stringify(body));
+        log.info(LOG_CATEGORY, "[Session PATCH] Request body:", JSON.stringify(body));
         
         const { videoUrl, status } = body;
 
@@ -159,16 +161,16 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         
         if (videoUrl) {
             updateData.videoUrl = videoUrl;
-            log.info("[Session PATCH] Video URL to save:", videoUrl);
+            log.info(LOG_CATEGORY, "[Session PATCH] Video URL to save:", videoUrl);
         }
         
         if (status) {
             updateData.status = status;
-            log.info("[Session PATCH] Status to save:", status);
+            log.info(LOG_CATEGORY, "[Session PATCH] Status to save:", status);
         }
 
         if (Object.keys(updateData).length === 0) {
-            log.error("[Session PATCH] ❌ No update fields provided");
+            log.error(LOG_CATEGORY, "[Session PATCH] ❌ No update fields provided");
             return NextResponse.json(
                 { error: "At least one field (videoUrl or status) is required" },
                 { status: 400 }
@@ -176,7 +178,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         }
 
         // Update the interview session
-        log.info("[Session PATCH] Executing prisma update...");
+        log.info(LOG_CATEGORY, "[Session PATCH] Executing prisma update...");
         
         const updatedSession = await prisma.interviewSession.update({
             where: {
@@ -185,7 +187,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             data: updateData,
         });
 
-        log.info("[Session PATCH] ✅ SUCCESS! Updated session:", {
+        log.info(LOG_CATEGORY, "[Session PATCH] ✅ SUCCESS! Updated session:", {
             id: updatedSession.id,
             videoUrl: updatedSession.videoUrl,
         });
@@ -195,10 +197,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             interviewSession: updatedSession,
         });
     } catch (error) {
-        log.error("[Session PATCH] ❌ ERROR:", error);
+        log.error(LOG_CATEGORY, "[Session PATCH] ❌ ERROR:", error);
         if (error instanceof Error) {
-            log.error("[Session PATCH] Error message:", error.message);
-            log.error("[Session PATCH] Error stack:", error.stack);
+            log.error(LOG_CATEGORY, "[Session PATCH] Error message:", error.message);
+            log.error(LOG_CATEGORY, "[Session PATCH] Error stack:", error.stack);
         }
         return NextResponse.json(
             { error: "Failed to update interview session" },

--- a/app/api/interviews/session/[sessionId]/terminate/route.ts
+++ b/app/api/interviews/session/[sessionId]/terminate/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId: string }>;
 };
@@ -21,7 +23,7 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
  */
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[Session TERMINATE] === TERMINATE REQUEST RECEIVED ===");
+        log.info(LOG_CATEGORY, "[Session TERMINATE] === TERMINATE REQUEST RECEIVED ===");
 
         const skipAuth = request.nextUrl.searchParams.get("skip-auth") === "true";
         const shouldSkipAuth = skipAuth;
@@ -31,19 +33,19 @@ export async function POST(request: NextRequest, context: RouteContext) {
         const sessionId = normalizeSessionId(rawSessionId);
 
         if (!sessionId) {
-            log.error("[Session TERMINATE] ❌ No session ID provided");
+            log.error(LOG_CATEGORY, "[Session TERMINATE] ❌ No session ID provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
             );
         }
 
-        log.info("[Session TERMINATE] Session ID:", sessionId);
+        log.info(LOG_CATEGORY, "[Session TERMINATE] Session ID:", sessionId);
 
         const userId = shouldSkipAuth ? null : (session?.user as any)?.id;
 
         if (!shouldSkipAuth && !userId) {
-            log.error("[Session TERMINATE] ❌ No user ID found");
+            log.error(LOG_CATEGORY, "[Session TERMINATE] ❌ No user ID found");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -59,7 +61,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.error("[Session TERMINATE] ❌ Session not found");
+            log.error(LOG_CATEGORY, "[Session TERMINATE] ❌ Session not found");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -77,14 +79,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[Session TERMINATE] ✅ Session marked as abandoned:", updatedSession.id);
+        log.info(LOG_CATEGORY, "[Session TERMINATE] ✅ Session marked as abandoned:", updatedSession.id);
 
         return NextResponse.json({
             message: "Interview session terminated",
             interviewSession: updatedSession,
         });
     } catch (error) {
-        log.error("[Session TERMINATE] ❌ ERROR:", error);
+        log.error(LOG_CATEGORY, "[Session TERMINATE] ❌ ERROR:", error);
         return NextResponse.json(
             { error: "Failed to terminate interview session" },
             { status: 500 }

--- a/app/api/interviews/session/[sessionId]/update-recording-start/route.ts
+++ b/app/api/interviews/session/[sessionId]/update-recording-start/route.ts
@@ -4,6 +4,8 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ sessionId?: string | string[] }>;
 };
@@ -17,31 +19,31 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
 
 export async function PATCH(request: NextRequest, context: RouteContext) {
     try {
-        log.info("[Update Recording Start] === REQUEST RECEIVED ===");
+        log.info(LOG_CATEGORY, "[Update Recording Start] === REQUEST RECEIVED ===");
         
         const skipAuth = request.nextUrl.searchParams.get("skip-auth") === "true";
         const shouldSkipAuth = skipAuth;
         
-        log.info("[Update Recording Start] Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "[Update Recording Start] Skip auth:", skipAuth);
 
         const session = await getServerSession(authOptions);
         const { sessionId: rawSessionId } = await context.params;
         const sessionId = normalizeSessionId(rawSessionId);
 
         if (!sessionId) {
-            log.error("[Update Recording Start] ❌ No session ID provided");
+            log.error(LOG_CATEGORY, "[Update Recording Start] ❌ No session ID provided");
             return NextResponse.json(
                 { error: "Interview session id is required" },
                 { status: 400 }
             );
         }
 
-        log.info("[Update Recording Start] Session ID:", sessionId);
+        log.info(LOG_CATEGORY, "[Update Recording Start] Session ID:", sessionId);
 
         const userId = shouldSkipAuth ? null : (session?.user as any)?.id;
         
         if (!shouldSkipAuth && !userId) {
-            log.error("[Update Recording Start] ❌ No user ID found and not in skip-auth/demo mode");
+            log.error(LOG_CATEGORY, "[Update Recording Start] ❌ No user ID found and not in skip-auth/demo mode");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -52,14 +54,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         const { recordingStartedAt } = body;
         
         if (!recordingStartedAt) {
-            log.error("[Update Recording Start] ❌ No recordingStartedAt provided");
+            log.error(LOG_CATEGORY, "[Update Recording Start] ❌ No recordingStartedAt provided");
             return NextResponse.json(
                 { error: "recordingStartedAt is required" },
                 { status: 400 }
             );
         }
         
-        log.info("[Update Recording Start] New recording start time:", recordingStartedAt);
+        log.info(LOG_CATEGORY, "[Update Recording Start] New recording start time:", recordingStartedAt);
         
         // Verify session exists and belongs to user
         const interviewSession = await prisma.interviewSession.findFirst({
@@ -70,7 +72,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         });
 
         if (!interviewSession) {
-            log.error("[Update Recording Start] ❌ Interview session not found");
+            log.error(LOG_CATEGORY, "[Update Recording Start] ❌ Interview session not found");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -85,7 +87,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             },
         });
 
-        log.info("[Update Recording Start] ✅ Updated session:", {
+        log.info(LOG_CATEGORY, "[Update Recording Start] ✅ Updated session:", {
             id: updatedSession.id,
             recordingStartedAt: updatedSession.recordingStartedAt,
         });
@@ -95,7 +97,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             interviewSession: updatedSession,
         });
     } catch (error) {
-        log.error("[Update Recording Start] ❌ ERROR:", error);
+        log.error(LOG_CATEGORY, "[Update Recording Start] ❌ ERROR:", error);
         return NextResponse.json(
             { error: "Failed to update recording start time" },
             { status: 500 }

--- a/app/api/interviews/session/route.ts
+++ b/app/api/interviews/session/route.ts
@@ -4,16 +4,18 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 export async function POST(request: NextRequest) {
     try {
-        log.info("🔍 Interview session creation API called");
+        log.info(LOG_CATEGORY, "🔍 Interview session creation API called");
 
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
 
         const session = await getServerSession(authOptions);
-        log.info("🔍 Session:", session ? "Found" : "Not found");
-        log.info("🔍 Skip auth:", skipAuth);
+        log.info(LOG_CATEGORY, "🔍 Session:", session ? "Found" : "Not found");
+        log.info(LOG_CATEGORY, "🔍 Skip auth:", skipAuth);
 
         const body = await request.json();
         const { applicationId, companyId, userId: requestUserId, recordingStartedAt } = body;
@@ -22,30 +24,30 @@ export async function POST(request: NextRequest) {
 
         if (skipAuth) {
             if (!requestUserId) {
-                log.warn("❌ skip-auth mode but no userId provided in request");
+                log.warn(LOG_CATEGORY, "❌ skip-auth mode but no userId provided in request");
                 return NextResponse.json(
                     { error: "userId required when skip-auth=true" },
                     { status: 400 }
                 );
             }
             userId = requestUserId;
-            log.info("✅ Skip auth - User ID from request:", userId);
+            log.info(LOG_CATEGORY, "✅ Skip auth - User ID from request:", userId);
         } else {
             if (!(session?.user as any)?.id) {
-                log.warn("❌ No user ID in session");
+                log.warn(LOG_CATEGORY, "❌ No user ID in session");
                 return NextResponse.json(
                     { error: "Unauthorized" },
                     { status: 401 }
                 );
             }
             userId = (session!.user as any).id;
-            log.info("✅ User ID from session:", userId);
+            log.info(LOG_CATEGORY, "✅ User ID from session:", userId);
         }
 
-        log.info("📋 Request data:", { applicationId, companyId });
+        log.info(LOG_CATEGORY, "📋 Request data:", { applicationId, companyId });
 
         if (!applicationId) {
-            log.warn("❌ Missing applicationId");
+            log.warn(LOG_CATEGORY, "❌ Missing applicationId");
             return NextResponse.json(
                 { error: "Application ID is required" },
                 { status: 400 }
@@ -53,7 +55,7 @@ export async function POST(request: NextRequest) {
         }
 
         // Verify the application exists and belongs to the user
-        log.info("🔎 Verifying application exists & belongs to user", {
+        log.info(LOG_CATEGORY, "🔎 Verifying application exists & belongs to user", {
             applicationId,
             userId,
         });
@@ -65,24 +67,24 @@ export async function POST(request: NextRequest) {
         });
 
         if (!application) {
-            log.warn("❌ Application not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "❌ Application not found or doesn't belong to user");
             return NextResponse.json(
                 { error: "Application not found" },
                 { status: 404 }
             );
         }
-        log.info("✅ Application verified");
+        log.info(LOG_CATEGORY, "✅ Application verified");
 
         // Create interview session AND zeroed telemetry in a single transaction
-        log.info(
+        log.info(LOG_CATEGORY, 
             "🚀 Creating interview session and zeroed telemetry (transaction)..."
         );
         let interviewSession; // for logging after transaction
         try {
             const txResult = await prisma.$transaction(async (tx) => {
-                log.info("🧾 [TX] Creating InterviewSession...");
+                log.info(LOG_CATEGORY, "🧾 [TX] Creating InterviewSession...");
                 const actualRecordingStartTime = recordingStartedAt ? new Date(recordingStartedAt) : new Date();
-                log.info("📹 Using recording start time:", actualRecordingStartTime.toISOString(), recordingStartedAt ? "(from client)" : "(fallback)");
+                log.info(LOG_CATEGORY, "📹 Using recording start time:", actualRecordingStartTime.toISOString(), recordingStartedAt ? "(from client)" : "(fallback)");
                 const interviewSession = await tx.interviewSession.create({
                     data: {
                         candidateId: userId,
@@ -91,11 +93,11 @@ export async function POST(request: NextRequest) {
                         recordingStartedAt: actualRecordingStartTime, // Use actual MediaRecorder start time
                     },
                 });
-                log.info("✅ [TX] InterviewSession created", {
+                log.info(LOG_CATEGORY, "✅ [TX] InterviewSession created", {
                     interviewSessionId: interviewSession.id,
                 });
 
-                log.info("🧾 [TX] Creating TelemetryData (zeroed)...");
+                log.info(LOG_CATEGORY, "🧾 [TX] Creating TelemetryData (zeroed)...");
                 const telemetry = await tx.telemetryData.create({
                     data: {
                         interviewSessionId: interviewSession.id,
@@ -105,11 +107,11 @@ export async function POST(request: NextRequest) {
                         hasFairnessFlag: false,
                     } as any,
                 });
-                log.info("✅ [TX] TelemetryData created", {
+                log.info(LOG_CATEGORY, "✅ [TX] TelemetryData created", {
                     telemetryId: telemetry.id,
                 });
 
-                log.info(
+                log.info(LOG_CATEGORY, 
                     "🧾 [TX] Creating WorkstyleMetrics (nullable baseline)..."
                 );
                 await tx.workstyleMetrics.create({
@@ -118,15 +120,15 @@ export async function POST(request: NextRequest) {
                         externalToolUsage: 0,
                     } as any,
                 });
-                log.info("✅ [TX] WorkstyleMetrics created for telemetry", {
+                log.info(LOG_CATEGORY, "✅ [TX] WorkstyleMetrics created for telemetry", {
                     telemetryId: telemetry.id,
                 });
 
-                log.info("🧾 [TX] Creating GapAnalysis (empty)...");
+                log.info(LOG_CATEGORY, "🧾 [TX] Creating GapAnalysis (empty)...");
                 await tx.gapAnalysis.create({
                     data: { telemetryDataId: telemetry.id },
                 });
-                log.info("✅ [TX] GapAnalysis created for telemetry", {
+                log.info(LOG_CATEGORY, "✅ [TX] GapAnalysis created for telemetry", {
                     telemetryId: telemetry.id,
                 });
 
@@ -134,7 +136,7 @@ export async function POST(request: NextRequest) {
             });
             interviewSession = txResult.interviewSession;
         } catch (txError: any) {
-            log.error(
+            log.error(LOG_CATEGORY, 
                 "💥 Transaction failed while creating session/telemetry",
                 {
                     name: txError?.name,
@@ -147,7 +149,7 @@ export async function POST(request: NextRequest) {
             throw txError; // handled by outer catch to return 500
         }
 
-        log.info(
+        log.info(LOG_CATEGORY, 
             "✅ Interview session and telemetry created:",
             interviewSession.id
         );
@@ -157,8 +159,8 @@ export async function POST(request: NextRequest) {
             interviewSession,
         });
     } catch (error: any) {
-        log.error("❌ Error creating interview session:", error);
-        log.error("❌ Error details:", {
+        log.error(LOG_CATEGORY, "❌ Error creating interview session:", error);
+        log.error(LOG_CATEGORY, "❌ Error details:", {
             name: error?.name,
             message: error?.message,
             stack: error?.stack,

--- a/app/api/interviews/session/screen-recording/route.ts
+++ b/app/api/interviews/session/screen-recording/route.ts
@@ -4,19 +4,21 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "interviews";
+
 export async function POST(request: NextRequest) {
     try {
-        log.info("Screen recording upload API called");
+        log.info(LOG_CATEGORY, "Screen recording upload API called");
 
         const session = await getServerSession(authOptions);
-        log.info("Session check:", session ? "Session found" : "No session");
-        log.info("User ID:", (session?.user as any)?.id);
+        log.info(LOG_CATEGORY, "Session check:", session ? "Session found" : "No session");
+        log.info(LOG_CATEGORY, "User ID:", (session?.user as any)?.id);
 
         const formData = await request.formData();
         const recording = formData.get("recording") as File;
 
-        log.info("Recording file received:", recording ? "Yes" : "No");
-        log.info(
+        log.info(LOG_CATEGORY, "Recording file received:", recording ? "Yes" : "No");
+        log.info(LOG_CATEGORY, 
             "File details:",
             recording
                 ? {
@@ -28,7 +30,7 @@ export async function POST(request: NextRequest) {
         );
 
         if (!recording) {
-            log.warn("❌ No recording file provided");
+            log.warn(LOG_CATEGORY, "❌ No recording file provided");
             return NextResponse.json(
                 { error: "Recording file is required" },
                 { status: 400 }
@@ -39,7 +41,7 @@ export async function POST(request: NextRequest) {
         const timestamp = Date.now();
         const filename = `recording-${timestamp}.mp4`;
 
-        log.info("Uploading to Vercel Blob:", filename);
+        log.info(LOG_CATEGORY, "Uploading to Vercel Blob:", filename);
 
         // Upload to Vercel Blob
         const blob = await put(filename, recording, {
@@ -49,7 +51,7 @@ export async function POST(request: NextRequest) {
 
         const recordingUrl = blob.url;
 
-        log.info("Recording uploaded successfully to Vercel Blob:", recordingUrl);
+        log.info(LOG_CATEGORY, "Recording uploaded successfully to Vercel Blob:", recordingUrl);
 
         return NextResponse.json({
             message: "Recording uploaded successfully",
@@ -57,7 +59,7 @@ export async function POST(request: NextRequest) {
             filename,
         });
     } catch (error) {
-        log.error("❌ Error uploading recording:", error);
+        log.error(LOG_CATEGORY, "❌ Error uploading recording:", error);
         return NextResponse.json(
             { error: "Failed to upload recording" },
             { status: 500 }

--- a/app/api/interviews/session/telemetry/route.ts
+++ b/app/api/interviews/session/telemetry/route.ts
@@ -4,21 +4,23 @@ import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 export async function POST(request: NextRequest) {
-    log.info("🚀 TELEMETRY API STARTED");
+    log.info(LOG_CATEGORY, "🚀 TELEMETRY API STARTED");
 
     try {
-        log.info("Interview telemetry creation API called");
+        log.info(LOG_CATEGORY, "Interview telemetry creation API called");
 
-        log.info("Attempting getServerSession()");
+        log.info(LOG_CATEGORY, "Attempting getServerSession()");
         const session = await getServerSession(authOptions);
-        log.info("Session result:", session);
-        log.info("Session user:", session?.user);
-        log.info("Session user ID:", (session?.user as any)?.id);
+        log.info(LOG_CATEGORY, "Session result:", session);
+        log.info(LOG_CATEGORY, "Session user:", session?.user);
+        log.info(LOG_CATEGORY, "Session user ID:", (session?.user as any)?.id);
 
         if (!(session?.user as any)?.id) {
-            log.warn("❌ No user ID in session");
-            log.info("❌ Session object:", JSON.stringify(session, null, 2));
+            log.warn(LOG_CATEGORY, "❌ No user ID in session");
+            log.info(LOG_CATEGORY, "❌ Session object:", JSON.stringify(session, null, 2));
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -26,32 +28,32 @@ export async function POST(request: NextRequest) {
         }
 
         const userId = (session!.user as any).id;
-        log.info("User ID:", userId);
-        log.info("Session validation passed");
+        log.info(LOG_CATEGORY, "User ID:", userId);
+        log.info(LOG_CATEGORY, "Session validation passed");
 
-        log.info("Parsing request body");
+        log.info(LOG_CATEGORY, "Parsing request body");
         const { interviewSessionId } = await request.json();
-        log.info("Request data:", { interviewSessionId });
-        log.info("Interview session ID type:", typeof interviewSessionId);
-        log.info("Interview session ID length:", interviewSessionId?.length);
+        log.info(LOG_CATEGORY, "Request data:", { interviewSessionId });
+        log.info(LOG_CATEGORY, "Interview session ID type:", typeof interviewSessionId);
+        log.info(LOG_CATEGORY, "Interview session ID length:", interviewSessionId?.length);
 
         if (!interviewSessionId) {
-            log.warn("❌ Missing interviewSessionId");
+            log.warn(LOG_CATEGORY, "❌ Missing interviewSessionId");
             return NextResponse.json(
                 { error: "Interview session ID is required" },
                 { status: 400 }
             );
         }
-        log.info("Request parsing passed");
+        log.info(LOG_CATEGORY, "Request parsing passed");
 
         // Verify the interview session exists and belongs to the user
-        log.info("Verifying interview session...");
-        log.info("Interview session ID:", interviewSessionId);
-        log.info("User ID:", userId);
+        log.info(LOG_CATEGORY, "Verifying interview session...");
+        log.info(LOG_CATEGORY, "Interview session ID:", interviewSessionId);
+        log.info(LOG_CATEGORY, "User ID:", userId);
 
         // Check if telemetry data already exists for this session
-        log.info("Checking for existing telemetry data...");
-        log.info("Looking for interviewSessionId:", interviewSessionId);
+        log.info(LOG_CATEGORY, "Checking for existing telemetry data...");
+        log.info(LOG_CATEGORY, "Looking for interviewSessionId:", interviewSessionId);
 
         let existingTelemetry;
         try {
@@ -60,10 +62,10 @@ export async function POST(request: NextRequest) {
                     interviewSessionId: interviewSessionId,
                 },
             });
-            log.info("findUnique result:", existingTelemetry);
+            log.info(LOG_CATEGORY, "findUnique result:", existingTelemetry);
         } catch (findError: any) {
-            log.error("Error in findUnique:", findError);
-            log.error("Find error details:", {
+            log.error(LOG_CATEGORY, "Error in findUnique:", findError);
+            log.error(LOG_CATEGORY, "Find error details:", {
                 name: findError?.name,
                 message: findError?.message,
                 code: findError?.code,
@@ -72,8 +74,8 @@ export async function POST(request: NextRequest) {
         }
 
         if (existingTelemetry) {
-        log.info("Telemetry data already exists:", existingTelemetry.id);
-        log.info("Returning existing telemetry data");
+        log.info(LOG_CATEGORY, "Telemetry data already exists:", existingTelemetry.id);
+        log.info(LOG_CATEGORY, "Returning existing telemetry data");
             return NextResponse.json({
                 message: "Telemetry data already exists",
                 telemetryData: {
@@ -85,7 +87,7 @@ export async function POST(request: NextRequest) {
             });
         }
 
-        log.info("No existing telemetry found; creating zeroed telemetry");
+        log.info(LOG_CATEGORY, "No existing telemetry found; creating zeroed telemetry");
 
         let interviewSession;
         try {
@@ -95,17 +97,17 @@ export async function POST(request: NextRequest) {
                     candidateId: userId,
                 },
             });
-            log.info(
+            log.info(LOG_CATEGORY, 
                 "Interview session query completed, result:",
                 interviewSession ? "Found" : "Not found"
             );
         } catch (sessionError: any) {
-            log.error("❌ Error in interview session query:", sessionError);
+            log.error(LOG_CATEGORY, "❌ Error in interview session query:", sessionError);
             throw sessionError;
         }
 
         if (!interviewSession) {
-            log.warn("❌ Interview session not found or doesn't belong to user");
+            log.warn(LOG_CATEGORY, "❌ Interview session not found or doesn't belong to user");
             return NextResponse.json(
                 { error: "Interview session not found" },
                 { status: 404 }
@@ -153,9 +155,9 @@ export async function POST(request: NextRequest) {
             },
         });
     } catch (error: any) {
-        log.info("Catch block entered");
-        log.error("❌ Error creating telemetry data:", error);
-        log.error("❌ Error details:", {
+        log.info(LOG_CATEGORY, "Catch block entered");
+        log.error(LOG_CATEGORY, "❌ Error creating telemetry data:", error);
+        log.error(LOG_CATEGORY, "❌ Error details:", {
             name: error?.name,
             message: error?.message,
             stack: error?.stack,
@@ -176,5 +178,5 @@ export async function POST(request: NextRequest) {
         );
     }
 
-    log.info("Function completed");
+    log.info(LOG_CATEGORY, "Function completed");
 }

--- a/app/api/interviews/shared/createVideoChapter.ts
+++ b/app/api/interviews/shared/createVideoChapter.ts
@@ -2,6 +2,8 @@ import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 import { CHAPTER_TYPES } from "./chapterTypes";
 
+const LOG_CATEGORY = "interviews";
+
 interface CreateVideoChapterParams {
     telemetryDataId: string;
     title: string;
@@ -22,7 +24,7 @@ interface CreateVideoChapterParams {
 export async function createVideoChapter(params: CreateVideoChapterParams) {
     const { telemetryDataId, title, startTime, description, caption } = params;
 
-    log.info("[createVideoChapter] Creating chapter:", {
+    log.info(LOG_CATEGORY, "[createVideoChapter] Creating chapter:", {
         title,
         startTime,
         telemetryDataId,
@@ -35,7 +37,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
         include: { captions: true },
     });
 
-    log.info("[createVideoChapter] Found existing chapters:", existingChapters.length);
+    log.info(LOG_CATEGORY, "[createVideoChapter] Found existing chapters:", existingChapters.length);
 
     // If no chapters exist and this is not at time 0, create Problem Presentation chapter
     if (existingChapters.length === 0 && startTime > 0) {
@@ -51,7 +53,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
                 thumbnailUrl: null,
             },
         });
-        log.info("[createVideoChapter] Created Problem Presentation chapter:", {
+        log.info(LOG_CATEGORY, "[createVideoChapter] Created Problem Presentation chapter:", {
             id: problemPresentationChapter.id,
             startTime: 0,
             endTime: startTime,
@@ -77,7 +79,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
         orderBy: { startTime: "asc" },
     });
 
-    log.info("[createVideoChapter] Adjacent chapters:", {
+    log.info(LOG_CATEGORY, "[createVideoChapter] Adjacent chapters:", {
         previous: previousChapter ? { title: previousChapter.title, startTime: previousChapter.startTime } : null,
         next: nextChapter ? { title: nextChapter.title, startTime: nextChapter.startTime } : null,
     });
@@ -88,7 +90,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
             where: { id: previousChapter.id },
             data: { endTime: startTime },
         });
-        log.info("[createVideoChapter] Updated previous chapter endTime:", {
+        log.info(LOG_CATEGORY, "[createVideoChapter] Updated previous chapter endTime:", {
             chapterId: previousChapter.id,
             title: previousChapter.title,
             newEndTime: startTime,
@@ -100,7 +102,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
                 where: { videoChapterId: previousChapter.id },
                 data: { endTime: startTime },
             });
-            log.info("[createVideoChapter] Updated previous chapter captions endTime");
+            log.info(LOG_CATEGORY, "[createVideoChapter] Updated previous chapter captions endTime");
         }
     }
 
@@ -121,7 +123,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
         },
     });
 
-    log.info("[createVideoChapter] Created new chapter:", {
+    log.info(LOG_CATEGORY, "[createVideoChapter] Created new chapter:", {
         id: newChapter.id,
         title: newChapter.title,
         startTime: newChapter.startTime,
@@ -138,7 +140,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
                 endTime: newChapterEndTime,
             },
         });
-        log.info("[createVideoChapter] Created caption");
+        log.info(LOG_CATEGORY, "[createVideoChapter] Created caption");
     }
 
     // Log all chapters after creation for debugging
@@ -146,7 +148,7 @@ export async function createVideoChapter(params: CreateVideoChapterParams) {
         where: { telemetryDataId },
         orderBy: { startTime: "asc" },
     });
-    log.info("[createVideoChapter] All chapters after creation:", 
+    log.info(LOG_CATEGORY, "[createVideoChapter] All chapters after creation:", 
         allChapters.map(c => ({ 
             title: c.title, 
             start: c.startTime, 

--- a/app/api/interviews/video-chapter/[chapterId]/caption/route.ts
+++ b/app/api/interviews/video-chapter/[chapterId]/caption/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "interviews";
+
 type RouteContext = {
     params: Promise<{ chapterId?: string | string[] }>;
 };
@@ -39,7 +41,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             );
         }
 
-        log.info("[VideoCaption Update API] Updating caption for chapter:", chapterId);
+        log.info(LOG_CATEGORY, "[VideoCaption Update API] Updating caption for chapter:", chapterId);
 
         // Find the VideoCaption for this chapter
         const videoCaption = await prisma.videoCaption.findFirst({
@@ -59,14 +61,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             data: { text: caption },
         });
 
-        log.info("[VideoCaption Update API] Caption updated successfully:", updatedCaption.id);
+        log.info(LOG_CATEGORY, "[VideoCaption Update API] Caption updated successfully:", updatedCaption.id);
 
         return NextResponse.json({
             message: "Caption updated successfully",
             captionId: updatedCaption.id,
         });
     } catch (error: any) {
-        log.error("[VideoCaption Update API] Error updating caption:", error);
+        log.error(LOG_CATEGORY, "[VideoCaption Update API] Error updating caption:", error);
         return NextResponse.json(
             {
                 error: "Failed to update caption",

--- a/app/api/upload/profile-image/route.ts
+++ b/app/api/upload/profile-image/route.ts
@@ -6,14 +6,16 @@ import path from "path";
 import { log } from "app/shared/services";
 import prisma from "lib/prisma";
 
+const LOG_CATEGORY = "upload";
+
 export async function POST(request: NextRequest) {
     try {
         const session = await getServerSession(authOptions);
-        log.info("Session:", session);
-        log.info("User ID:", (session?.user as any)?.id);
+        log.info(LOG_CATEGORY, "Session:", session);
+        log.info(LOG_CATEGORY, "User ID:", (session?.user as any)?.id);
 
         if (!(session?.user as any)?.id) {
-            log.error("No session or user ID found");
+            log.error(LOG_CATEGORY, "No session or user ID found");
             return NextResponse.json(
                 { error: "Unauthorized" },
                 { status: 401 }
@@ -22,13 +24,13 @@ export async function POST(request: NextRequest) {
 
         const data = await request.formData();
         const file = data.get("image") as File;
-        log.info("File received:", file);
-        log.info("File name:", file?.name);
-        log.info("File size:", file?.size);
-        log.info("File type:", file?.type);
+        log.info(LOG_CATEGORY, "File received:", file);
+        log.info(LOG_CATEGORY, "File name:", file?.name);
+        log.info(LOG_CATEGORY, "File size:", file?.size);
+        log.info(LOG_CATEGORY, "File type:", file?.type);
 
         if (!file) {
-            log.error("No file provided");
+            log.error(LOG_CATEGORY, "No file provided");
             return NextResponse.json(
                 { error: "No file provided" },
                 { status: 400 }
@@ -82,7 +84,7 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ imageUrl });
     } catch (error) {
-        log.error("Upload error:", error);
+        log.error(LOG_CATEGORY, "Upload error:", error);
         return NextResponse.json(
             { error: "Internal server error" },
             { status: 500 }

--- a/app/api/user/applications/route.ts
+++ b/app/api/user/applications/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth/next";
 import { log } from "app/shared/services";
 import { authOptions, prisma } from "app/shared/services/server";
 
+const LOG_CATEGORY = "applications";
+
 export async function GET(request: NextRequest) {
     try {
         const session = await getServerSession(authOptions);
@@ -40,7 +42,7 @@ export async function GET(request: NextRequest) {
             total: appliedCompanyIds.length,
         });
     } catch (error) {
-        log.error("Error fetching user applications:", error);
+        log.error(LOG_CATEGORY, "Error fetching user applications:", error);
         return NextResponse.json(
             {
                 error: `Failed to fetch applications: ${

--- a/app/api/users/[id]/name/route.ts
+++ b/app/api/users/[id]/name/route.ts
@@ -4,6 +4,8 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "users";
+
 const prisma = new PrismaClient();
 
 type RouteContext = {
@@ -42,14 +44,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
             data: { name: name.trim() },
         });
 
-        log.info(`Updated user ${userId} name to: ${name.trim()}`);
+        log.info(LOG_CATEGORY, `Updated user ${userId} name to: ${name.trim()}`);
 
         return NextResponse.json({
             success: true,
             name: updatedUser.name,
         });
     } catch (error) {
-        log.error("Error updating user name:", error);
+        log.error(LOG_CATEGORY, "Error updating user name:", error);
         return NextResponse.json(
             { error: "Failed to update user name" },
             { status: 500 }

--- a/app/shared/contexts/job-application-context.tsx
+++ b/app/shared/contexts/job-application-context.tsx
@@ -10,6 +10,8 @@ import React, {
 import { useSession } from "next-auth/react";
 import { log } from "app/shared/services";
 
+const LOG_CATEGORY = "job-application";
+
 interface JobApplicationState {
     appliedCompanies: string[]; // Array of company IDs
     loading: boolean;
@@ -91,11 +93,11 @@ export function JobApplicationProvider({ children }: { children: ReactNode }) {
                             payload: data.appliedCompanyIds,
                         });
                     } else {
-                        log.error("Failed to fetch applied companies");
+                        log.error(LOG_CATEGORY, "Failed to fetch applied companies");
                         dispatch({ type: "LOAD_FROM_DATABASE", payload: [] });
                     }
                 } catch (error) {
-                    log.error("Error fetching applied companies:", error);
+                    log.error(LOG_CATEGORY, "Error fetching applied companies:", error);
                     dispatch({ type: "LOAD_FROM_DATABASE", payload: [] });
                 }
             } else if (status === "unauthenticated") {

--- a/app/shared/services/auth.ts
+++ b/app/shared/services/auth.ts
@@ -6,6 +6,8 @@ import bcrypt from "bcryptjs";
 import { prisma } from "./prisma";
 import { log } from "./logger";
 
+const LOG_CATEGORY = "auth";
+
 const googleClientId = process.env.GOOGLE_CLIENT_ID;
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
@@ -14,7 +16,7 @@ const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
  */
 function createGoogleProvider() {
     if (!googleClientId || !googleClientSecret) {
-        log.error("Missing Google OAuth configuration", {
+        log.error(LOG_CATEGORY, "Missing Google OAuth configuration", {
             provider: "google",
             hasClientId: Boolean(googleClientId),
             hasClientSecret: Boolean(googleClientSecret),
@@ -24,7 +26,7 @@ function createGoogleProvider() {
         );
     }
 
-    log.info("Google OAuth provider configured", { provider: "google" });
+    log.info(LOG_CATEGORY, "Google OAuth provider configured", { provider: "google" });
 
     return GoogleProvider({
         clientId: googleClientId,
@@ -89,16 +91,16 @@ export const authOptions: NextAuthOptions = {
     },
     callbacks: {
         async jwt({ token, user, trigger, session }) {
-            log.info("JWT callback triggered:", { user, trigger, session });
+            log.info(LOG_CATEGORY, "JWT callback triggered:", { user, trigger, session });
             if (user) {
                 token.role = (user as any).role;
                 token.image = (user as any).image;
-                log.info("JWT token updated with image:", token.image);
+                log.info(LOG_CATEGORY, "JWT token updated with image:", token.image);
             }
             // Handle session update
             if (trigger === "update" && session?.image) {
                 token.image = session.image;
-                log.info(
+                log.info(LOG_CATEGORY, 
                     "JWT token updated via session update:",
                     token.image
                 );
@@ -106,7 +108,7 @@ export const authOptions: NextAuthOptions = {
             return token;
         },
         async session({ session, token }) {
-            log.info("Session callback triggered with token:", {
+            log.info(LOG_CATEGORY, "Session callback triggered with token:", {
                 sub: token.sub,
                 role: token.role,
                 image: token.image,
@@ -115,7 +117,7 @@ export const authOptions: NextAuthOptions = {
                 (session.user as any).id = token.sub!;
                 (session.user as any).role = token.role as string;
                 (session.user as any).image = token.image as string;
-                log.info(
+                log.info(LOG_CATEGORY, 
                     "Session updated with image:",
                     (session.user as any).image
                 );

--- a/app/shared/services/cache.ts
+++ b/app/shared/services/cache.ts
@@ -6,6 +6,8 @@
 import NodeCache from "node-cache";
 import { log } from "./logger";
 
+const LOG_CATEGORY = "cache";
+
 const TTL_SECONDS = 300; // 5 minutes
 
 const cache = new NodeCache({
@@ -20,10 +22,10 @@ const cache = new NodeCache({
 export async function getCached<T>(key: string): Promise<T | null> {
     const value = cache.get<T>(key);
     if (value !== undefined) {
-        log.debug(`[Cache] HIT: ${key}`);
+        log.debug(LOG_CATEGORY, `[Cache] HIT: ${key}`);
         return value;
     }
-    log.debug(`[Cache] MISS: ${key}`);
+    log.debug(LOG_CATEGORY, `[Cache] MISS: ${key}`);
     return null;
 }
 
@@ -36,7 +38,7 @@ export async function setCached<T>(
     ttl?: number
 ): Promise<void> {
     cache.set(key, value, ttl ?? TTL_SECONDS);
-    log.debug(`[Cache] SET: ${key}`);
+    log.debug(LOG_CATEGORY, `[Cache] SET: ${key}`);
 }
 
 /**
@@ -45,7 +47,7 @@ export async function setCached<T>(
 export function invalidate(key: string): void {
     const deleted = cache.del(key);
     if (deleted > 0) {
-        log.info(`[Cache] INVALIDATE: ${key}`);
+        log.info(LOG_CATEGORY, `[Cache] INVALIDATE: ${key}`);
     }
 }
 
@@ -57,7 +59,7 @@ export function invalidatePattern(pattern: string): void {
     const matching = keys.filter((key) => key.startsWith(pattern));
     if (matching.length > 0) {
         cache.del(matching);
-        log.info(`[Cache] INVALIDATE_PATTERN: ${pattern} (${matching.length} keys)`);
+        log.info(LOG_CATEGORY, `[Cache] INVALIDATE_PATTERN: ${pattern} (${matching.length} keys)`);
     }
 }
 

--- a/app/shared/services/logger.config.ts
+++ b/app/shared/services/logger.config.ts
@@ -1,4 +1,14 @@
+/** Logger configuration for levels, categories, and label overrides. */
 export const LOG_LEVEL = "info" as const; // 'debug' | 'info' | 'warn' | 'error' | 'silent'
+
+/** Category filter mode for log emission. */
+export type CategoryFilterMode = "allowlist" | "blocklist";
+
+/** Category filter mode that determines how CATEGORY_FILTER is interpreted. */
+export const CATEGORY_FILTER_MODE: CategoryFilterMode = "blocklist";
+
+/** Category filter values for the current filter mode. */
+export const CATEGORY_FILTER: string[] = [];
 
 // Empty means: allow all files to log
 export const ALLOWLIST: (string | RegExp)[] = [];

--- a/app/shared/services/logger.ts
+++ b/app/shared/services/logger.ts
@@ -1,9 +1,27 @@
+/**
+ * Logger service with file and category filtering.
+ */
 import loglevel from "loglevel";
-import { LABEL_OVERRIDES } from "./logger.config";
+import { CATEGORY_FILTER, CATEGORY_FILTER_MODE, LABEL_OVERRIDES } from "./logger.config";
 
 export type LogLevel = "debug" | "info" | "warn" | "error" | "silent";
+export type LogCategory = string;
 
 let allowedMatchers: (string | RegExp)[] = [];
+
+function assertCategory(category: LogCategory): string {
+    if (!category || typeof category !== "string") {
+        throw new Error("Log category is required.");
+    }
+    return category;
+}
+
+function isCategoryAllowed(category: LogCategory): boolean {
+    if (CATEGORY_FILTER_MODE === "allowlist") {
+        return CATEGORY_FILTER.includes(category);
+    }
+    return !CATEGORY_FILTER.includes(category);
+}
 
 function applyLabelOverrides(filePath: string, computed: string): string {
     for (const o of LABEL_OVERRIDES) {
@@ -110,17 +128,27 @@ loglevel.methodFactory = function (methodName, logLevel, loggerName) {
 // Re-apply current level after methodFactory override
 loglevel.setLevel(loglevel.getLevel());
 
+function emitLog(level: LogLevel, category: LogCategory, args: any[]): void {
+    const verifiedCategory = assertCategory(category);
+    if (!isCategoryAllowed(verifiedCategory)) return;
+    const prefixedArgs = [`[${verifiedCategory}]`, ...args];
+    loglevel[level](...prefixedArgs);
+}
+
+/** Logger that requires a category for each call. */
 export const log = {
-    debug: (...args: any[]) => loglevel.debug(...args),
-    info: (...args: any[]) => loglevel.info(...args),
-    warn: (...args: any[]) => loglevel.warn(...args),
-    error: (...args: any[]) => loglevel.error(...args),
+    debug: (category: LogCategory, ...args: any[]) => emitLog("debug", category, args),
+    info: (category: LogCategory, ...args: any[]) => emitLog("info", category, args),
+    warn: (category: LogCategory, ...args: any[]) => emitLog("warn", category, args),
+    error: (category: LogCategory, ...args: any[]) => emitLog("error", category, args),
 };
 
+/** Set the global log level. */
 export function setLevel(level: LogLevel) {
     loglevel.setLevel(level as loglevel.LogLevelDesc);
 }
 
+/** Set file matchers that are allowed to emit logs. */
 export function setAllowedFiles(matchers: (string | RegExp)[]) {
     allowedMatchers = Array.isArray(matchers) ? matchers : [];
 }

--- a/research.md
+++ b/research.md
@@ -1,0 +1,7 @@
+# Library Scan
+
+## Logger category filtering
+- **Candidates:** loglevel built-in configuration, loglevel-plugin-prefix, loglevel-plugin-remote, loglevel-filter.
+- **Decision:** keep existing loglevel usage and add lightweight category filtering in the local logger wrapper.
+- **Rationale:** existing logger already wraps loglevel and provides label filtering; category filtering is a small extension without additional runtime dependencies.
+- **Alternatives:** adopt loglevel-filter or replace logger with a structured logging library (e.g., pino) for category routing.

--- a/server/db-scripts/seed-data.ts
+++ b/server/db-scripts/seed-data.ts
@@ -9,7 +9,7 @@ import { log } from "app/shared/services";
 // Note: DATABASE_URL should be set by the calling script (sync-schema-and-seed.ts)
 // or in environment variables before running this script directly
 if (!process.env.DATABASE_URL) {
-    log.error("❌ DATABASE_URL is not set. Please run via sync:dev or sync:prod");
+    log.error(LOG_CATEGORY, "❌ DATABASE_URL is not set. Please run via sync:dev or sync:prod");
     process.exit(1);
 }
 
@@ -142,6 +142,8 @@ Build a Python class called QuantumCircuitSimulator that:
 
 import numpy as np
 
+const LOG_CATEGORY = "db";
+
 class QuantumCircuitSimulator:
     def __init__(self, num_qubits=2):
         # Your code here
@@ -203,7 +205,7 @@ async function resetDatabase() {
         const companiesData = JSON.parse(
             fs.readFileSync(companiesPath, "utf-8")
         );
-        log.info("Clearing existing data...");
+        log.info(LOG_CATEGORY, "Clearing existing data...");
 
         // Delete in reverse order of dependencies
         await prisma.job.deleteMany();
@@ -213,7 +215,7 @@ async function resetDatabase() {
         await prisma.candidateProfile.deleteMany();
         await prisma.user.deleteMany();
 
-        log.info("Seeding companies, users, and jobs...");
+        log.info(LOG_CATEGORY, "Seeding companies, users, and jobs...");
 
         // Hash the password once for all users
         const hashedPassword = await bcrypt.hash("sfinx", 12);
@@ -231,7 +233,7 @@ async function resetDatabase() {
                 },
             });
 
-            log.info(`Created company: ${company.name}`);
+            log.info(LOG_CATEGORY, `Created company: ${company.name}`);
 
             // Create user account for company manager
             const managerEmail = `manager@${companyData.name
@@ -274,7 +276,7 @@ async function resetDatabase() {
                 },
             });
 
-            log.info(`   └─ Created manager account: ${managerEmail}`);
+            log.info(LOG_CATEGORY, `   └─ Created manager account: ${managerEmail}`);
 
             // Create jobs for this company
             for (const jobData of companyData.openRoles) {
@@ -292,10 +294,10 @@ async function resetDatabase() {
                 });
             }
 
-            log.info(`   └─ Created ${companyData.openRoles.length} jobs for ${company.name}`);
+            log.info(LOG_CATEGORY, `   └─ Created ${companyData.openRoles.length} jobs for ${company.name}`);
         }
 
-        log.info("Creating candidate user...");
+        log.info(LOG_CATEGORY, "Creating candidate user...");
         const candidateUser = await prisma.user.create({
             data: {
                 id: "candidate-noam-hoze",
@@ -323,9 +325,9 @@ async function resetDatabase() {
             },
         });
 
-        log.info(`   └─ Created candidate account: ${candidateUser.email}`);
+        log.info(LOG_CATEGORY, `   └─ Created candidate account: ${candidateUser.email}`);
 
-        log.info("Creating candidate user Noam Best...");
+        log.info(LOG_CATEGORY, "Creating candidate user Noam Best...");
         const noamBest = await prisma.user.create({
             data: {
                 id: "candidate-noam-best",
@@ -352,9 +354,9 @@ async function resetDatabase() {
             },
         });
 
-        log.info(`   └─ Created candidate account: ${noamBest.email}`);
+        log.info(LOG_CATEGORY, `   └─ Created candidate account: ${noamBest.email}`);
 
-        log.info("Creating candidate user Noam Worst...");
+        log.info(LOG_CATEGORY, "Creating candidate user Noam Worst...");
         const noamWorst = await prisma.user.create({
             data: {
                 id: "candidate-noam-worst",
@@ -381,9 +383,9 @@ async function resetDatabase() {
             },
         });
 
-        log.info(`   └─ Created candidate account: ${noamWorst.email}`);
+        log.info(LOG_CATEGORY, `   └─ Created candidate account: ${noamWorst.email}`);
 
-        log.info("Seeding shared interview content for all Frontend Engineer roles...");
+        log.info(LOG_CATEGORY, "Seeding shared interview content for all Frontend Engineer roles...");
         const interviewContent = await prisma.interviewContent.upsert({
             where: {
                 id: SHARED_FRONTEND_INTERVIEW.id,
@@ -458,11 +460,11 @@ async function resetDatabase() {
         if (frontendJobUpdate.count === 0) {
             throw new Error("No Frontend Engineer jobs found to attach interview content");
         }
-        log.info(
+        log.info(LOG_CATEGORY, 
             `Linked interview content to ${frontendJobUpdate.count} Frontend Engineer jobs (including Meta)`
         );
 
-        log.info("Seeding QM Python interview content for Senior Python Engineer role...");
+        log.info(LOG_CATEGORY, "Seeding QM Python interview content for Senior Python Engineer role...");
         const qmInterviewContent = await prisma.interviewContent.upsert({
             where: {
                 id: QM_PYTHON_INTERVIEW.id,
@@ -549,12 +551,12 @@ async function resetDatabase() {
         if (pythonJobUpdate.count === 0) {
             throw new Error("No Senior Python Engineer jobs found to attach interview content");
         }
-        log.info(
+        log.info(LOG_CATEGORY, 
             `Linked interview content to ${pythonJobUpdate.count} Senior Python Engineer jobs (QM)`
         );
 
         // Create default scoring configurations for all jobs
-        log.info("Creating default scoring configurations...");
+        log.info(LOG_CATEGORY, "Creating default scoring configurations...");
         const jobsWithoutScoring = await prisma.job.findMany({
             where: {
                 scoringConfiguration: null,
@@ -572,17 +574,17 @@ async function resetDatabase() {
                 },
             });
         }
-        log.info(`Created scoring configurations for ${jobsWithoutScoring.length} jobs`);
+        log.info(LOG_CATEGORY, `Created scoring configurations for ${jobsWithoutScoring.length} jobs`);
 
-        log.info("Database reset and seeded successfully!");
+        log.info(LOG_CATEGORY, "Database reset and seeded successfully!");
 
         // Print summary
         const companyCount = await prisma.company.count();
         const jobCount = await prisma.job.count();
         const userCount = await prisma.user.count();
-        log.info(`Summary: ${companyCount} companies, ${userCount} users, ${jobCount} jobs`);
+        log.info(LOG_CATEGORY, `Summary: ${companyCount} companies, ${userCount} users, ${jobCount} jobs`);
     } catch (error) {
-        log.error("❌ Error resetting database:", error);
+        log.error(LOG_CATEGORY, "❌ Error resetting database:", error);
         process.exit(1);
     } finally {
         await prisma.$disconnect();

--- a/server/db-scripts/sync-schema-and-seed.ts
+++ b/server/db-scripts/sync-schema-and-seed.ts
@@ -5,8 +5,10 @@ import { PrismaClient } from "@prisma/client";
 import { log } from "app/shared/services";
 import fs from "fs";
 
+const LOG_CATEGORY = "db";
+
 async function syncSchemaAndSeed() {
-    log.info("Starting database reset with new schema...");
+    log.info(LOG_CATEGORY, "Starting database reset with new schema...");
 
     try {
         // Parse CLI flag: --env=dev or --env=prod
@@ -25,8 +27,8 @@ async function syncSchemaAndSeed() {
             throw new Error(`${environment === 'dev' ? 'DEV_DATABASE_URL' : 'PROD_DATABASE_URL'} is not set in environment variables`);
         }
         
-        log.info(`Running on: ${environment.toUpperCase()}`);
-        log.info(`Database: ${databaseUrl.split('@')[1]?.split('/')[0]}`);
+        log.info(LOG_CATEGORY, `Running on: ${environment.toUpperCase()}`);
+        log.info(LOG_CATEGORY, `Database: ${databaseUrl.split('@')[1]?.split('/')[0]}`);
         
         // Set DATABASE_URL in process.env for PrismaClient
         process.env.DATABASE_URL = databaseUrl;
@@ -40,21 +42,21 @@ async function syncSchemaAndSeed() {
         };
 
         // 1. Generate Prisma client with the latest schema
-        log.info("⚡ Generating Prisma client...");
+        log.info(LOG_CATEGORY, "⚡ Generating Prisma client...");
         execSync("pnpm prisma generate --schema server/prisma/schema.prisma", execOptions);
 
         // 2. Push the new schema to the database (apply DDL)
-        log.info("🚀 Pushing new schema to database...");
+        log.info(LOG_CATEGORY, "🚀 Pushing new schema to database...");
         execSync("pnpm prisma db push --schema server/prisma/schema.prisma --accept-data-loss", execOptions);
 
         // 3. Reset and seed data against the new schema
-        log.info(
+        log.info(LOG_CATEGORY, 
             "📦 Resetting and seeding database (fresh data on new schema)..."
         );
         execSync("pnpm seed", execOptions);
 
         // 4. Verify the schema was applied correctly
-        log.info("Verifying schema...");
+        log.info(LOG_CATEGORY, "Verifying schema...");
         const prisma = new PrismaClient();
 
         // Test that we can query the new relationship
@@ -65,22 +67,22 @@ async function syncSchemaAndSeed() {
             take: 1,
         });
 
-        log.info("Schema verification successful!");
-        log.info("Database reset and new schema applied successfully!");
-        log.info("");
-        log.info("New relationship confirmed:");
-        log.info("   - Application.interviewSessions: InterviewSession[]");
-        log.info(
+        log.info(LOG_CATEGORY, "Schema verification successful!");
+        log.info(LOG_CATEGORY, "Database reset and new schema applied successfully!");
+        log.info(LOG_CATEGORY, "");
+        log.info(LOG_CATEGORY, "New relationship confirmed:");
+        log.info(LOG_CATEGORY, "   - Application.interviewSessions: InterviewSession[]");
+        log.info(LOG_CATEGORY, 
             "   - One application can now have many interview sessions"
         );
 
         await prisma.$disconnect();
 
         // 5. Open Prisma Studio for quick inspection
-        log.info("Opening Prisma Studio...");
+        log.info(LOG_CATEGORY, "Opening Prisma Studio...");
         execSync("pnpm prisma studio --schema server/prisma/schema.prisma", execOptions);
     } catch (error) {
-        log.error("❌ Error during database reset:", error);
+        log.error(LOG_CATEGORY, "❌ Error during database reset:", error);
         process.exit(1);
     }
 }

--- a/shared/services/backgroundInterview/useBackgroundAnswerHandler.ts
+++ b/shared/services/backgroundInterview/useBackgroundAnswerHandler.ts
@@ -18,6 +18,8 @@ import { buildOpenAIBackgroundPrompt } from "@/shared/prompts/openAIInterviewerP
 import { buildControlContextMessages, CONTROL_CONTEXT_TURNS } from "app/shared/services";
 import { log } from "app/shared/services/logger";
 
+const LOG_CATEGORY = "background-interview";
+
 interface AnswerHandlerResult {
   transitionReason?: string;
   shouldComplete: boolean;
@@ -53,14 +55,14 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
         })
       });
     } catch (err) {
-      log.error("Failed to save message:", err);
+      log.error(LOG_CATEGORY, "Failed to save message:", err);
     }
   };
 
   const handleSubmit = useCallback(
     async (answer: string, openaiClient: OpenAI | null, candidateName: string): Promise<AnswerHandlerResult> => {
       if (!openaiClient || !companyName) {
-        log.info("Submit blocked - missing openaiClient or companyName");
+        log.info(LOG_CATEGORY, "Submit blocked - missing openaiClient or companyName");
         return { shouldComplete: false };
       }
 
@@ -112,7 +114,7 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
             // Use updated counts from evaluation response
             categoryStats = evalData.updatedCounts || [];
           } catch (err) {
-            log.error("Failed to evaluate answer:", err);
+            log.error(LOG_CATEGORY, "Failed to evaluate answer:", err);
           } finally {
             dispatch(setEvaluatingAnswer({ evaluating: false }));
           }
@@ -120,7 +122,7 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
 
         // Transition machine state
         const ms = store.getState().interview;
-        log.info("Interview stage:", ms.stage);
+        log.info(LOG_CATEGORY, "Interview stage:", ms.stage);
 
         if (ms.stage === "background") {
           const backgroundState = store.getState().background;
@@ -140,7 +142,7 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
                 }));
               }
             } catch (err) {
-              log.error("Failed to fetch contributions:", err);
+              log.error(LOG_CATEGORY, "Failed to fetch contributions:", err);
             }
           }
           
@@ -149,11 +151,11 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
             { timeboxMs, categories }
           );
 
-          log.info("Time gate check:", { transitionReason, categories });
+          log.info(LOG_CATEGORY, "Time gate check:", { transitionReason, categories });
 
           if (transitionReason) {
             // Time limit reached - generate closing response
-            log.info(`Time limit reached (${transitionReason})`);
+            log.info(LOG_CATEGORY, `Time limit reached (${transitionReason})`);
             const persona = buildOpenAIBackgroundPrompt(String(companyName), script?.experienceCategories);
             const firstName = candidateName.split(" ")[0] || "Candidate";
             const closingInstruction = `Say exactly: "Thank you so much ${firstName}, the next steps will be shared with you shortly."`;
@@ -171,15 +173,15 @@ export function useBackgroundAnswerHandler(onEvaluationReceived?: (data: any) =>
               dispatch(addMessage({ text: systemMsg, speaker: "system" as any }));
               // Don't save system message to DB to keep transcript clean
               
-              log.info("Final response generated");
+              log.info(LOG_CATEGORY, "Final response generated");
             } catch (err) {
-              log.error("Failed to generate final response:", err);
+              log.error(LOG_CATEGORY, "Failed to generate final response:", err);
             }
 
             return { transitionReason, shouldComplete: true };
           } else {
             // Generate follow-up question with category-aware guidance
-            log.info("Generating follow-up question...");
+            log.info(LOG_CATEGORY, "Generating follow-up question...");
             
             // Build category guidance using fresh data from evaluation
             const TARGET_CONTRIBUTIONS = 5;
@@ -240,19 +242,19 @@ ${coverageList}
 ${focusGuidance}`;
             }
             
-            log.info("Category guidance:", categoryGuidance);
+            log.info(LOG_CATEGORY, "Category guidance:", categoryGuidance);
             
             // Add last answer context to guidance
             let answerContext = "";
             if (isBlankAnswer) {
               const previousQuestion = currentQuestion || "the question";
               answerContext = `\n\nINSTRUCTION: The candidate didn't know the answer to: "${previousQuestion}"\n\n1. Acknowledge briefly that they're unsure (e.g., "I understand that's challenging")\n2. Generate a completely NEW question on a DIFFERENT angle or aspect\n3. Stay within the target category from the guidance above\n4. DO NOT repeat any question from the conversation history`;
-              log.info("BLANK ANSWER DETECTED - sending special instruction");
+              log.info(LOG_CATEGORY, "BLANK ANSWER DETECTED - sending special instruction");
             } else {
               answerContext = `\n\nCandidate's last answer: "${answer}"\nRespond contextually to what they said.`;
             }
             
-            log.info("Answer context:", answerContext.substring(0, 150));
+            log.info(LOG_CATEGORY, "Answer context:", answerContext.substring(0, 150));
             
             const persona = buildOpenAIBackgroundPrompt(String(companyName), script?.experienceCategories) + categoryGuidance + answerContext;
             const historyMessages = buildControlContextMessages(CONTROL_CONTEXT_TURNS);
@@ -260,16 +262,16 @@ ${focusGuidance}`;
             const followUpRaw = await askViaChatCompletion(openaiClient, persona, historyMessages);
 
             if (followUpRaw) {
-              log.info("Raw OpenAI response:", followUpRaw);
+              log.info(LOG_CATEGORY, "Raw OpenAI response:", followUpRaw);
               try {
                 // Parse JSON response
                 const parsed = JSON.parse(followUpRaw);
-                log.info("Parsed JSON:", parsed);
+                log.info(LOG_CATEGORY, "Parsed JSON:", parsed);
                 const question = parsed.question || followUpRaw;
                 const targetedCategory = parsed.targetedCategory || null;
 
-                log.info("Extracted question:", question);
-                log.info("Targeted category:", targetedCategory);
+                log.info(LOG_CATEGORY, "Extracted question:", question);
+                log.info(LOG_CATEGORY, "Targeted category:", targetedCategory);
 
                 dispatch(addMessage({ text: question, speaker: "ai" }));
                 saveMessageToDb(question, "ai");
@@ -278,11 +280,11 @@ ${focusGuidance}`;
                   dispatch(setCurrentQuestionTarget({ question, category: targetedCategory }));
                 }
 
-                log.info("Follow-up question generated and dispatched");
+                log.info(LOG_CATEGORY, "Follow-up question generated and dispatched");
               } catch (err) {
                 // Fallback if not JSON
-                log.error("JSON parse failed:", err);
-                log.warn("Using raw text as fallback");
+                log.error(LOG_CATEGORY, "JSON parse failed:", err);
+                log.warn(LOG_CATEGORY, "Using raw text as fallback");
                 dispatch(addMessage({ text: followUpRaw, speaker: "ai" }));
                 saveMessageToDb(followUpRaw, "ai");
               }
@@ -294,7 +296,7 @@ ${focusGuidance}`;
 
         return { shouldComplete: false };
       } catch (error) {
-        log.error("Error processing answer:", error);
+        log.error(LOG_CATEGORY, "Error processing answer:", error);
         throw error;
       }
     },


### PR DESCRIPTION
### Motivation
- Add category support to the logger so every log call includes a required category and operators can enable/disable categories via configuration.

### Description
- Replace the logger API to require a `category` parameter and introduce `CATEGORY_FILTER` and `CATEGORY_FILTER_MODE` in `app/shared/services/logger.config.ts` for allowlist/blocklist behavior.
- Implement `emitLog`, `assertCategory`, and `isCategoryAllowed` in `app/shared/services/logger.ts` and export a `log` object that enforces `log.<level>(category, ...)` usage.
- Migrate many callsites to declare a `LOG_CATEGORY` constant and update calls to `log.<level>(LOG_CATEGORY, ...)`, and add `research.md` documenting the library scan and decision.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963df1f8de0832b82181b8ded022f6b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes logging to category-based usage across the app.
> 
> - Adds `LOG_CATEGORY` constants and updates all `log.info/error/warn` calls to pass the category first (UI pages and numerous API routes)
> - Normalizes log messages and context objects; aligns with new logger API contract
> - Broad, cross-cutting refactor; no business logic or API behavior changes expected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b4a430cdc04f15a124465f530d8a1191aa4f22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->