### PR TITLE
Replace console logs with structured logger, add runtime logging tests, and fix sessionId scope

### DIFF
--- a/app/(features)/company-dashboard/ApplicantsByJob.tsx
+++ b/app/(features)/company-dashboard/ApplicantsByJob.tsx
@@ -7,6 +7,10 @@ import { useDispatch } from "react-redux";
 import { setNavigationSource } from "@/shared/state/slices/navigationSlice";
 import SfinxSpinner from "app/shared/components/SfinxSpinner";
 import { DashboardPageLayout } from "app/shared/components";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.COMPANY_DASHBOARD;
 
 interface JobWithApplicants {
     id: string;
@@ -161,7 +165,11 @@ export default function ApplicantsByJob() {
                 setJobs(data.jobs);
             }
         } catch (error) {
-            console.error("Failed to fetch jobs:", error);
+            log.error(LOG_CATEGORY, "Failed to fetch jobs", {
+                userId: session?.user?.id,
+                pathname,
+                errorMessage: error instanceof Error ? error.message : String(error),
+            });
         } finally {
             setLoading(false);
         }

--- a/app/(features)/cps/components/EvidenceReel.tsx
+++ b/app/(features)/cps/components/EvidenceReel.tsx
@@ -9,6 +9,10 @@ import {
     defaultLayoutIcons,
 } from "@vidstack/react/player/layouts/default";
 import EvidenceNavigationOverlay from "./EvidenceNavigationOverlay";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.CPS;
 
 interface EvidenceLink {
     timestamp: number;
@@ -86,7 +90,12 @@ export default function EvidenceReel({
                     if (playPromise !== undefined) {
                         playPromise.catch((error: any) => {
                             // Ignore auto-play errors (e.g. not allowed or not ready)
-                            console.warn("[EvidenceReel] Auto-play prevented:", error);
+                            log.warn(LOG_CATEGORY, "[EvidenceReel] Auto-play prevented", {
+                                jumpKey,
+                                jumpToTime,
+                                hasVideoUrl: Boolean(videoUrl),
+                                errorMessage: error instanceof Error ? error.message : String(error),
+                            });
                         });
                     }
                 }

--- a/app/(features)/cps/page.tsx
+++ b/app/(features)/cps/page.tsx
@@ -89,17 +89,31 @@ function TelemetryContent() {
 
                 if (response.ok) {
                     const data = await response.json();
-                    console.log("[CPS] Telemetry data received:", data);
+                    const sessionCount = Array.isArray(data.sessions) ? data.sessions.length : undefined;
+                    const firstSessionId = Array.isArray(data.sessions) ? data.sessions[0]?.id : undefined;
+                    log.info(LOG_CATEGORY, "[CPS] Telemetry data received", {
+                        candidateId,
+                        applicationId,
+                        sessionCount,
+                        firstSessionId,
+                    });
                     // Supports new API shape with sessions[]
                     if (data.sessions) {
-                        console.log("[CPS] Sessions found:", data.sessions.length);
-                        console.log("[CPS] First session videoUrl:", data.sessions[0]?.videoUrl);
+                        log.info(LOG_CATEGORY, "[CPS] Sessions available", {
+                            candidateId,
+                            applicationId,
+                            sessionCount,
+                        });
                         setTelemetryData({ candidate: data.candidate });
                         setSessions(data.sessions || []);
                         setActiveSessionIndex(0);
                     } else {
                         // Backward compatibility with single-session shape
-                        console.log("[CPS] Using legacy format, videoUrl:", data.videoUrl);
+                        log.info(LOG_CATEGORY, "[CPS] Using legacy telemetry format", {
+                            candidateId,
+                            applicationId,
+                            hasVideoUrl: Boolean(data.videoUrl),
+                        });
                         setTelemetryData(data);
                         setSessions([
                             {
@@ -124,7 +138,11 @@ function TelemetryContent() {
                     setTelemetryData(null);
                 }
             } catch (error) {
-                log.error(LOG_CATEGORY, "Error fetching telemetry:", error);
+                log.error(LOG_CATEGORY, "Error fetching telemetry", {
+                    candidateId,
+                    applicationId,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                });
                 setError("Failed to load telemetry data");
                 setTelemetryData(null);
             } finally {
@@ -160,7 +178,10 @@ function TelemetryContent() {
                     setBackgroundSummary(null);
                 }
             } catch (error) {
-                log.error(LOG_CATEGORY, "Error fetching background summary:", error);
+                log.error(LOG_CATEGORY, "Error fetching background summary", {
+                    sessionId,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                });
                 setBackgroundSummary(null);
             } finally {
                 setSummaryLoading(false);
@@ -192,7 +213,10 @@ function TelemetryContent() {
                     setCodingSummary(null);
                 }
             } catch (error) {
-                log.error(LOG_CATEGORY, "Error fetching coding summary:", error);
+                log.error(LOG_CATEGORY, "Error fetching coding summary", {
+                    sessionId,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                });
                 setCodingSummary(null);
             } finally {
                 setCodingSummaryLoading(false);
@@ -222,7 +246,10 @@ function TelemetryContent() {
                     }
                 }
             } catch (error) {
-                log.error(LOG_CATEGORY, "Error fetching scoring configuration:", error);
+                log.error(LOG_CATEGORY, "Error fetching scoring configuration", {
+                    jobId,
+                    errorMessage: error instanceof Error ? error.message : String(error),
+                });
                 setScoringConfig(null);
             }
         };
@@ -269,14 +296,6 @@ function TelemetryContent() {
                 const scaleFactor = categoryTotalWeight / dbWeightSum;
                 
                 // #region agent log
-                const dbCategories = Object.keys(codingSummary.jobSpecificCategories);
-                const jobCategoryNames = jobCodingCategories.map((c: any) => c.name);
-                console.log('[CPS DEBUG] DB categories:', dbCategories);
-                console.log('[CPS DEBUG] Job categories:', jobCategoryNames);
-                console.log('[CPS DEBUG] Full jobSpecificCategories:', codingSummary.jobSpecificCategories);
-                console.log('[CPS DEBUG] Scale factor:', scaleFactor, 'DB weight sum:', dbWeightSum);
-                // #endregion
-                
                 jobCodingCategories.forEach((categoryDef: any) => {
                     // Match by base name (before any parentheses)
                     const baseName = categoryDef.name.split(' (')[0];
@@ -286,10 +305,6 @@ function TelemetryContent() {
                     
                     const score = codingSummary.jobSpecificCategories[matchingKey]?.score || 0;
                     const scaledWeight = categoryDef.weight * scaleFactor;
-                    
-                    // #region agent log
-                    console.log(`[CPS DEBUG] ${categoryDef.name}: dbWeight=${categoryDef.weight}, scaledWeight=${scaledWeight}, score=${score}`);
-                    // #endregion
                     
                     categoryScores.push({
                         name: categoryDef.name,
@@ -312,21 +327,22 @@ function TelemetryContent() {
             setCalculatedScore(result.finalScore);
             setCalculatedExperienceScore(result.experienceScore);
             setCalculatedCodingScore(result.codingScore);
-            
-            // #region agent log
-            console.log('[CPS SCORE CALC] Experience:', result.experienceScore, 'Coding:', result.codingScore, 'Final:', result.finalScore);
-            console.log('[CPS SCORE CALC] Category scores WITH WEIGHTS:', categoryScores.map(c => ({name: c.name, score: c.score, weight: c.weight})));
-            console.log('[CPS SCORE CALC] AI Assist:', workstyleMetrics.aiAssistAccountabilityScore, 'Weight:', scoringConfig.aiAssistWeight);
-            // #endregion
+            log.info(LOG_CATEGORY, "[CPS] Calculated score", {
+                sessionId: activeSession?.id,
+                experienceScore: result.experienceScore,
+                codingScore: result.codingScore,
+                finalScore: result.finalScore,
+            });
         } catch (error) {
-            log.error(LOG_CATEGORY, "Error calculating score:", error);
+            log.error(LOG_CATEGORY, "Error calculating score", {
+                sessionId: activeSession?.id,
+                errorMessage: error instanceof Error ? error.message : String(error),
+            });
             setCalculatedScore(null);
             setCalculatedExperienceScore(null);
             setCalculatedCodingScore(null);
         }
     }, [backgroundSummary, codingSummary, scoringConfig, activeSession?.workstyle, activeSession?.application?.job?.codingCategories, activeSession?.application?.job?.experienceCategories]);
-
-    console.log("[CPS] Active session:", activeSession);
     const formatMonthYear = (dateIso?: string) =>
         dateIso
             ? new Date(dateIso).toLocaleDateString(undefined, {
@@ -336,8 +352,6 @@ function TelemetryContent() {
             : "";
     const { gaps, evidence, chapters, workstyle, videoUrl, duration } =
         activeSession;
-    console.log("[CPS] Extracted videoUrl:", videoUrl, "duration:", duration);
-    console.log("[CPS] Chapters:", chapters, "Count:", chapters?.length || 0);
     const persistenceFlow = activeSession.persistenceFlow || [];
     const learningToAction = activeSession.learningToAction || [];
     const confidenceCurve = activeSession.confidenceCurve || [];

--- a/app/api/candidates/[id]/basic/route.ts
+++ b/app/api/candidates/[id]/basic/route.ts
@@ -3,6 +3,9 @@ import { PrismaClient } from "@prisma/client";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "app/shared/services/auth";
 import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.USERS;
 
 const prisma = new PrismaClient();
 
@@ -15,6 +18,8 @@ type RouteContext = {
  * Supports skip-auth for demo mode.
  */
 export async function GET(request: NextRequest, context: RouteContext) {
+    const requestId = request.headers.get("x-request-id");
+    let candidateId: string | undefined;
     try {
         const url = new URL(request.url);
         const skipAuth = url.searchParams.get("skip-auth") === "true";
@@ -26,7 +31,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
             }
         }
 
-        const { id: candidateId } = await context.params;
+        const params = await context.params;
+        candidateId = params.id;
 
         const candidate = await prisma.user.findUnique({
             where: { id: candidateId },
@@ -59,7 +65,11 @@ export async function GET(request: NextRequest, context: RouteContext) {
             score: matchScore,
         });
     } catch (error) {
-        console.error('Error fetching candidate basic info:', error);
+        log.error(LOG_CATEGORY, "Error fetching candidate basic info", {
+            requestId,
+            candidateId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             { error: 'Failed to fetch candidate info' },
             { status: 500 }

--- a/app/api/company/jobs/[jobId]/applicants/route.ts
+++ b/app/api/company/jobs/[jobId]/applicants/route.ts
@@ -1,34 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions, getCached, setCached } from "app/shared/services/server";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
 import prisma from "lib/prisma";
+
+const LOG_CATEGORY = LOG_CATEGORIES.COMPANY;
 
 /**
  * Extracts top 2-3 category highlights from interview session data.
  */
 function extractTopHighlights(session: any): string[] {
-  console.log("[HIGHLIGHTS] Session:", session?.id);
-  console.log("[HIGHLIGHTS] TelemetryData:", session?.telemetryData);
-  
   const telemetryArray = Array.isArray(session?.telemetryData) 
     ? session.telemetryData 
     : session?.telemetryData ? [session.telemetryData] : [];
   
   if (telemetryArray.length === 0) {
-    console.log("[HIGHLIGHTS] No telemetry data found");
     return [];
   }
 
   const telemetry = telemetryArray[0];
-  console.log("[HIGHLIGHTS] Telemetry:", telemetry);
-  console.log("[HIGHLIGHTS] BackgroundSummary:", telemetry.backgroundSummary);
-  console.log("[HIGHLIGHTS] CodingSummary:", telemetry.codingSummary);
-  
   const allCategories: Array<{ name: string; score: number }> = [];
 
   if (telemetry.backgroundSummary?.experienceCategories) {
     const expCats = telemetry.backgroundSummary.experienceCategories;
-    console.log("[HIGHLIGHTS] ExperienceCategories:", expCats);
     Object.entries(expCats).forEach(([key, value]: [string, any]) => {
       if (value?.score != null) {
         allCategories.push({ name: value.name || key, score: value.score });
@@ -38,7 +33,6 @@ function extractTopHighlights(session: any): string[] {
 
   if (telemetry.codingSummary?.jobSpecificCategories) {
     const codeCats = telemetry.codingSummary.jobSpecificCategories;
-    console.log("[HIGHLIGHTS] JobSpecificCategories:", codeCats);
     Object.entries(codeCats).forEach(([key, value]: [string, any]) => {
       if (value?.score != null) {
         allCategories.push({ name: value.name || key, score: value.score });
@@ -46,12 +40,10 @@ function extractTopHighlights(session: any): string[] {
     });
   }
 
-  console.log("[HIGHLIGHTS] AllCategories:", allCategories);
   const result = allCategories
     .sort((a, b) => b.score - a.score)
     .slice(0, 3)
     .map((c) => c.name);
-  console.log("[HIGHLIGHTS] Result:", result);
   
   return result;
 }
@@ -64,6 +56,8 @@ export async function GET(
   request: NextRequest,
   context: { params: Promise<{ jobId: string }> }
 ) {
+  const requestId = request.headers.get("x-request-id");
+  let jobId: string | undefined;
   try {
     const session = await getServerSession(authOptions);
     if (!session?.user) {
@@ -75,7 +69,8 @@ export async function GET(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { jobId } = await context.params;
+    const params = await context.params;
+    jobId = params.jobId;
 
     const cacheKey = `applicants:job:${jobId}`;
     const cached = await getCached<any>(cacheKey);
@@ -190,11 +185,14 @@ export async function GET(
     await setCached(cacheKey, result);
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Error fetching job applicants:", error);
+    log.error(LOG_CATEGORY, "Error fetching job applicants", {
+      requestId,
+      jobId,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
     );
   }
 }
-

--- a/app/api/interviews/chat/route.ts
+++ b/app/api/interviews/chat/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
+import { log } from "app/shared/services";
 import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.OPENAI;
 
 const openai = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
@@ -11,6 +14,7 @@ const openai = new OpenAI({
  * Handles all OpenAI chat interactions: persona setup, question generation, and follow-ups
  */
 export async function POST(request: NextRequest) {
+    const requestId = request.headers.get("x-request-id");
     try {
         const body = await request.json();
         const { persona, instruction, conversationHistory } = body;
@@ -22,18 +26,15 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("→ OpenAI Request [chat" + (instruction ? " - initial setup" : " - follow-up") + "]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("Model: gpt-4o-mini");
-        console.log("\nPersona (System):", persona);
-        if (instruction) {
-            console.log("\nInstruction:", instruction);
-        }
-        if (conversationHistory && conversationHistory.length > 0) {
-            console.log("\nConversation History:");
-            console.log(JSON.stringify(conversationHistory, null, 2));
-        }
+        const conversationTurnCount = Array.isArray(conversationHistory) ? conversationHistory.length : undefined;
+        log.info(LOG_CATEGORY, "[chat] OpenAI request prepared", {
+            requestId,
+            hasInstruction: Boolean(instruction),
+            conversationTurnCount,
+            personaLength: persona.length,
+            instructionLength: instruction ? instruction.length : undefined,
+            model: "gpt-4o-mini",
+        });
 
         let messages;
         if (conversationHistory && conversationHistory.length > 0) {
@@ -60,11 +61,10 @@ export async function POST(request: NextRequest) {
 
         const result = completion.choices?.[0]?.message?.content?.trim();
 
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("← OpenAI Response [generate-question]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log(result);
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        log.info(LOG_CATEGORY, "[chat] OpenAI response received", {
+            requestId,
+            responseLength: result ? result.length : undefined,
+        });
 
         if (!result) {
             throw new Error("OpenAI returned empty response");
@@ -72,7 +72,10 @@ export async function POST(request: NextRequest) {
 
         return NextResponse.json({ response: result });
     } catch (error: any) {
-        console.error("[generate-question] Error:", error);
+        log.error(LOG_CATEGORY, "[chat] OpenAI request failed", {
+            requestId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             { error: error.message || "Failed to generate question" },
             { status: 500 }

--- a/app/api/interviews/evaluate-answer-fast/route.ts
+++ b/app/api/interviews/evaluate-answer-fast/route.ts
@@ -16,9 +16,12 @@ const openai = new OpenAI({
  * Fast evaluation: returns only category scores and next question (no reasoning/captions/DB saves)
  */
 export async function POST(request: NextRequest) {
+    const requestId = request.headers.get("x-request-id");
+    let sessionId: string | undefined;
     try {
         const body = await request.json();
-        const { sessionId, question, answer, experienceCategories, currentCounts, currentFocusTopic, conversationHistory, excludedTopics, answerHistory } = body;
+        sessionId = body.sessionId;
+        const { question, answer, experienceCategories, currentCounts, currentFocusTopic, conversationHistory, excludedTopics, answerHistory } = body;
 
         if (!sessionId || !question || answer === undefined || !experienceCategories || !currentCounts) {
             return NextResponse.json(
@@ -34,7 +37,10 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info(LOG_CATEGORY, "[evaluate-answer-fast] Fast evaluation started");
+        log.info(LOG_CATEGORY, "[evaluate-answer-fast] Fast evaluation started", {
+            requestId,
+            sessionId,
+        });
 
         // Fetch session to get company/job context
         const session = await prisma.interviewSession.findUnique({
@@ -71,7 +77,10 @@ export async function POST(request: NextRequest) {
 
         // Check if all categories excluded
         if (activeCategories.length === 0) {
-            log.info(LOG_CATEGORY, "[evaluate-answer-fast] All categories excluded - ending interview");
+            log.info(LOG_CATEGORY, "[evaluate-answer-fast] All categories excluded - ending interview", {
+                requestId,
+                sessionId,
+            });
             return NextResponse.json({
                 success: true,
                 allCategoriesExcluded: true,
@@ -177,12 +186,13 @@ Return JSON:
                 content: fastPrompt,
             },
         ];
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("→ OpenAI Request [evaluate-answer-fast]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("Model:", evaluationModel);
-        console.log("\nSystem:", messages[0].content);
-        console.log("\nUser Prompt:", messages[1].content);
+        log.info(LOG_CATEGORY, "[evaluate-answer-fast] OpenAI request prepared", {
+            requestId,
+            sessionId,
+            model: evaluationModel,
+            promptLength: fastPrompt.length,
+            messageCount: messages.length,
+        });
 
         const completion = await openai.chat.completions.create({
             model: evaluationModel,
@@ -192,11 +202,11 @@ Return JSON:
         });
 
         const responseText = completion.choices[0]?.message?.content;
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("← OpenAI Response [evaluate-answer-fast]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log(JSON.stringify(JSON.parse(responseText || "{}"), null, 2));
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        log.info(LOG_CATEGORY, "[evaluate-answer-fast] OpenAI response received", {
+            requestId,
+            sessionId,
+            responseLength: responseText ? responseText.length : undefined,
+        });
         
         if (!responseText) {
             throw new Error("OpenAI returned empty response");
@@ -234,7 +244,10 @@ Return JSON:
                 
                 // Check if all categories now excluded
                 if (newActiveCategories.length === 0) {
-                    log.info(LOG_CATEGORY, "[evaluate-answer-fast] All categories excluded after increment");
+                    log.info(LOG_CATEGORY, "[evaluate-answer-fast] All categories excluded after increment", {
+                        requestId,
+                        sessionId,
+                    });
                     return NextResponse.json({
                         success: true,
                         allCategoriesExcluded: true,
@@ -325,7 +338,11 @@ Return JSON:
             };
         });
 
-        log.info(LOG_CATEGORY, "[evaluate-answer-fast] Fast evaluation complete");
+        log.info(LOG_CATEGORY, "[evaluate-answer-fast] Fast evaluation complete", {
+            requestId,
+            sessionId,
+            updatedCount: updatedCounts.length,
+        });
 
         return NextResponse.json({
             success: true,
@@ -337,7 +354,11 @@ Return JSON:
             evaluationIntent: result.evaluationIntent || "",
         });
     } catch (error) {
-        log.error(LOG_CATEGORY, "[evaluate-answer-fast] ❌ Error:", error);
+        log.error(LOG_CATEGORY, "[evaluate-answer-fast] Error", {
+            requestId,
+            sessionId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             { error: error instanceof Error ? error.message : "Unknown error" },
             { status: 500 }

--- a/app/api/interviews/evaluate-answer/route.ts
+++ b/app/api/interviews/evaluate-answer/route.ts
@@ -17,9 +17,12 @@ const openai = new OpenAI({
  * Evaluates background interview answers and creates evidence clips for experience categories
  */
 export async function POST(request: NextRequest) {
+    const requestId = request.headers.get("x-request-id");
+    let sessionId: string | undefined;
     try {
         const body = await request.json();
-        const { sessionId, question, answer, timestamp, experienceCategories, currentCounts } = body;
+        sessionId = body.sessionId;
+        const { question, answer, timestamp, experienceCategories, currentCounts } = body;
 
         if (!sessionId || !question || answer === undefined || !timestamp || !experienceCategories) {
             return NextResponse.json(
@@ -32,7 +35,10 @@ export async function POST(request: NextRequest) {
             throw new Error("currentCounts is required - must be passed from Redux store");
         }
 
-        log.info(LOG_CATEGORY, "[evaluate-answer] Evaluating answer for session:", sessionId);
+        log.info(LOG_CATEGORY, "[evaluate-answer] Evaluating answer for session", {
+            requestId,
+            sessionId,
+        });
 
         // Fetch session with recording data and job
         const session = await prisma.interviewSession.findUnique({
@@ -65,7 +71,10 @@ export async function POST(request: NextRequest) {
         }
 
         if (!categoriesToEvaluate || categoriesToEvaluate.length === 0) {
-            log.info(LOG_CATEGORY, "[evaluate-answer] No experience categories defined for this job - skipping evaluation");
+            log.info(LOG_CATEGORY, "[evaluate-answer] No experience categories defined for this job - skipping evaluation", {
+                requestId,
+                sessionId,
+            });
             return NextResponse.json({
                 success: true,
                 contributionsCount: 0,
@@ -163,7 +172,10 @@ CRITICAL RULES:
 - Blank or gibberish answers MUST be scored 0 across all categories.
 - Be strict with 0 scores - use them for noise, blank answers, and gibberish.`;
 
-        log.info(LOG_CATEGORY, "[evaluate-answer] Calling OpenAI for evaluation");
+        log.info(LOG_CATEGORY, "[evaluate-answer] Calling OpenAI for evaluation", {
+            requestId,
+            sessionId,
+        });
 
         const evaluationModel = process.env.NEXT_PUBLIC_OPENAI_EVALUATION_MODEL;
         if (!evaluationModel) {
@@ -181,12 +193,13 @@ CRITICAL RULES:
             },
         ];
 
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("→ OpenAI Request [evaluate-answer FULL]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("Model:", evaluationModel);
-        console.log("\nSystem:", messages[0].content);
-        console.log("\nUser Prompt:", evaluationPrompt.substring(0, 500) + "...");
+        log.info(LOG_CATEGORY, "[evaluate-answer] OpenAI request prepared", {
+            requestId,
+            sessionId,
+            model: evaluationModel,
+            promptLength: evaluationPrompt.length,
+            messageCount: messages.length,
+        });
 
         const completion = await openai.chat.completions.create({
             model: evaluationModel,
@@ -201,13 +214,11 @@ CRITICAL RULES:
 
         const evaluation = JSON.parse(responseText);
         
-        console.log("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log("← OpenAI Response [evaluate-answer FULL]");
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        console.log(JSON.stringify(evaluation, null, 2));
-        console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
-        
-        log.info(LOG_CATEGORY, "[evaluate-answer] OpenAI evaluation:", evaluation);
+        log.info(LOG_CATEGORY, "[evaluate-answer] OpenAI response received", {
+            requestId,
+            sessionId,
+            evaluationCount: Array.isArray(evaluation?.evaluations) ? evaluation.evaluations.length : undefined,
+        });
 
         // Helper: Map contribution strength to normalized points
         const getNormalizedPoints = (strength: number): number => {
@@ -333,12 +344,24 @@ CRITICAL RULES:
 
         // Fire-and-forget DB operations (async, non-blocking)
         Promise.all(dbOperations).then(() => {
-            log.info(LOG_CATEGORY, `[evaluate-answer] ✅ Async DB save complete. ${evaluation.evaluations.filter((e: any) => e.strength > 0).length} contributions saved.`);
+            const savedCount = evaluation.evaluations.filter((e: any) => e.strength > 0).length;
+            log.info(LOG_CATEGORY, "[evaluate-answer] Async DB save complete", {
+                requestId,
+                sessionId,
+                savedCount,
+            });
         }).catch(err => {
-            log.error(LOG_CATEGORY, "[evaluate-answer] ❌ Async DB save failed:", err);
+            log.error(LOG_CATEGORY, "[evaluate-answer] Async DB save failed", {
+                requestId,
+                sessionId,
+                errorMessage: err instanceof Error ? err.message : String(err),
+            });
         });
 
-        log.info(LOG_CATEGORY, `[evaluate-answer] Returning updated counts immediately (DB saves in background)`);
+        log.info(LOG_CATEGORY, "[evaluate-answer] Returning updated counts immediately (DB saves in background)", {
+            requestId,
+            sessionId,
+        });
 
         // Return immediately with in-memory calculated counts
         return NextResponse.json({
@@ -348,11 +371,14 @@ CRITICAL RULES:
             updatedCounts: updatedCounts,
         });
     } catch (error) {
-        log.error(LOG_CATEGORY, "[evaluate-answer] ❌ Error:", error);
+        log.error(LOG_CATEGORY, "[evaluate-answer] Error", {
+            requestId,
+            sessionId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             { error: error instanceof Error ? error.message : "Unknown error" },
             { status: 500 }
         );
     }
 }
-

--- a/app/api/interviews/evaluate-output/route.ts
+++ b/app/api/interviews/evaluate-output/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.INTERVIEWS;
 
 const openaiClient = new OpenAI({
     apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY,
 });
 
 export async function POST(req: NextRequest) {
+    const requestId = req.headers.get("x-request-id");
     try {
         const {
             actualOutput,
@@ -73,7 +78,10 @@ Evaluate if the actual output matches the expected output. Return ONLY valid JSO
 
         return NextResponse.json(evaluation);
     } catch (error: any) {
-        console.error("[evaluate-output] Error:", error);
+        log.error(LOG_CATEGORY, "[evaluate-output] Error", {
+            requestId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             {
                 error: "Failed to evaluate output",
@@ -83,4 +91,3 @@ Evaluate if the actual output matches the expected output. Return ONLY valid JSO
         );
     }
 }
-

--- a/app/api/interviews/generate-profile-story/route.ts
+++ b/app/api/interviews/generate-profile-story/route.ts
@@ -23,9 +23,11 @@ interface CategoryScore {
  * Generates a human-readable profile story for a candidate based on interview summaries.
  */
 export async function POST(request: NextRequest) {
+    const requestId = request.headers.get("x-request-id");
+    let sessionId: string | undefined;
     try {
         const body = await request.json();
-        const { sessionId } = body;
+        sessionId = body.sessionId;
 
         if (!sessionId) {
             return NextResponse.json({ error: "Session ID required" }, { status: 400 });
@@ -62,7 +64,10 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Fetching evaluation data for session:", sessionId);
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Fetching evaluation data for session", {
+            requestId,
+            sessionId,
+        });
 
         const [iterations, codingContributions, experienceContributions, externalToolUsages] = await Promise.all([
             prisma.iteration.findMany({ 
@@ -91,7 +96,10 @@ export async function POST(request: NextRequest) {
 
         const hasCodeActivity = iterations.length > 0 || codingContributions.length > 0;
 
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Code activity detected:", hasCodeActivity, {
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Code activity detected", {
+            requestId,
+            sessionId,
+            hasCodeActivity,
             iterations: iterations.length,
             codingContributions: codingContributions.length,
             experienceContributions: experienceContributions.length,
@@ -105,13 +113,18 @@ export async function POST(request: NextRequest) {
             codingContributions
         );
 
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Organized data:", {
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Organized data", {
+            requestId,
+            sessionId,
             strongestCount: organizedData.strongest.length,
             weakestCount: organizedData.weakest.length
         });
 
         // PASS 1: Extract key elements
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Pass 1: Extracting key elements");
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Pass 1: Extracting key elements", {
+            requestId,
+            sessionId,
+        });
         
         const extractionPrompt = buildExtractionPrompt(
             session.candidate.name || "The candidate",
@@ -129,11 +142,20 @@ export async function POST(request: NextRequest) {
         });
 
         const extractedData = JSON.parse(extractionResponse.choices[0]?.message?.content || "{}");
-        
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Extracted data:", extractedData);
+        const extractedKeyCount = extractedData && typeof extractedData === "object"
+            ? Object.keys(extractedData).length
+            : undefined;
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Extracted data summary", {
+            requestId,
+            sessionId,
+            extractedKeyCount,
+        });
 
         // PASS 2: Format into 250 characters
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Pass 2: Formatting to 250 characters");
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Pass 2: Formatting to 250 characters", {
+            requestId,
+            sessionId,
+        });
 
         const formattingPrompt = buildFormattingPrompt(
             session.candidate.name || "The candidate",
@@ -158,7 +180,11 @@ export async function POST(request: NextRequest) {
             const trimmed = story.slice(0, 300);
             const lastPeriod = trimmed.lastIndexOf('.');
             story = lastPeriod > 150 ? trimmed.slice(0, lastPeriod + 1) : trimmed;
-            log.info(LOG_CATEGORY, "[Generate Profile Story] Truncated story to", story.length, "characters (complete sentence)");
+            log.info(LOG_CATEGORY, "[Generate Profile Story] Truncated story to complete sentence", {
+                requestId,
+                sessionId,
+                storyLength: story.length,
+            });
         }
 
         await prisma.telemetryData.update({
@@ -166,10 +192,16 @@ export async function POST(request: NextRequest) {
             data: { story },
         });
 
-        log.info(LOG_CATEGORY, "[Generate Profile Story] Story saved to database");
+        log.info(LOG_CATEGORY, "[Generate Profile Story] Story saved to database", {
+            requestId,
+            sessionId,
+        });
 
         if (!hasCodeActivity) {
-            log.info(LOG_CATEGORY, "[Generate Profile Story] No code activity detected - story reflects zero coding engagement");
+            log.info(LOG_CATEGORY, "[Generate Profile Story] No code activity detected - story reflects zero coding engagement", {
+                requestId,
+                sessionId,
+            });
         }
 
         // Return prompts in development mode for debugging
@@ -182,8 +214,11 @@ export async function POST(request: NextRequest) {
             } : undefined
         });
     } catch (error) {
-        log.error(LOG_CATEGORY, "[Generate Profile Story] Error:", error);
-        console.error("[Generate Profile Story] Full error details:", error);
+        log.error(LOG_CATEGORY, "[Generate Profile Story] Error", {
+            requestId,
+            sessionId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         
         // Return detailed error in development
         const errorMessage = error instanceof Error ? error.message : String(error);

--- a/app/api/interviews/session/[sessionId]/iterations/route.ts
+++ b/app/api/interviews/session/[sessionId]/iterations/route.ts
@@ -15,8 +15,11 @@ export async function POST(
     request: NextRequest,
     context: RouteContext
 ) {
+    const requestId = request.headers.get("x-request-id");
+    let sessionId: string | undefined;
     try {
-        const { sessionId } = await context.params;
+        const params = await context.params;
+        sessionId = params.sessionId;
         
         const {
             timestamp,
@@ -85,7 +88,11 @@ export async function POST(
                     where: { id: session.telemetryData.workstyleMetrics.id },
                     data: { iterationSpeed: iterationCount },
                 });
-                console.log(`✅ [Iterations API] First CORRECT solution at iteration ${iterationCount}`);
+                log.info(LOG_CATEGORY, "[Iterations API] First CORRECT solution", {
+                    requestId,
+                    sessionId,
+                    iterationCount,
+                });
             }
         }
 
@@ -94,7 +101,9 @@ export async function POST(
             const iterationTimestamp = timestamp ? new Date(timestamp) : new Date();
             const videoOffset = Math.floor((iterationTimestamp.getTime() - session.recordingStartedAt.getTime()) / 1000);
             
-            log.info(LOG_CATEGORY, "📹 [Iterations API] Creating evidence for iteration", {
+            log.info(LOG_CATEGORY, "[Iterations API] Creating evidence for iteration", {
+                requestId,
+                sessionId,
                 recordingStartedAt: session.recordingStartedAt.toISOString(),
                 iterationTimestamp: iterationTimestamp.toISOString(),
                 videoOffset,
@@ -143,15 +152,29 @@ export async function POST(
                     });
                 }
                 
-                log.info(LOG_CATEGORY, `✅ [Iterations API] Created evidence clips for iteration at ${videoOffset}s`);
+                log.info(LOG_CATEGORY, "[Iterations API] Created evidence clips for iteration", {
+                    requestId,
+                    sessionId,
+                    videoOffset,
+                    iterationCount,
+                });
             } else {
-                log.warn(LOG_CATEGORY, "⚠️ [Iterations API] Negative video offset, skipping evidence creation");
+                log.warn(LOG_CATEGORY, "[Iterations API] Negative video offset, skipping evidence creation", {
+                    requestId,
+                    sessionId,
+                    videoOffset,
+                    iterationCount,
+                });
             }
         }
 
         return NextResponse.json(iteration);
     } catch (error: any) {
-        console.error("[iterations] Error creating iteration:", error);
+        log.error(LOG_CATEGORY, "[iterations] Error creating iteration", {
+            requestId,
+            sessionId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             {
                 error: "Failed to create iteration",
@@ -166,17 +189,29 @@ export async function GET(
     request: NextRequest,
     context: RouteContext
 ) {
+    const requestId = request.headers.get("x-request-id");
+    let sessionId: string | undefined;
     try {
-        const { sessionId } = await context.params;
+        const params = await context.params;
+        sessionId = params.sessionId;
 
         const iterations = await prisma.iteration.findMany({
             where: { interviewSessionId: sessionId },
             orderBy: { timestamp: "asc" },
         });
 
+        log.debug(LOG_CATEGORY, "[iterations] Iterations fetched", {
+            requestId,
+            sessionId,
+            iterationCount: iterations.length,
+        });
         return NextResponse.json(iterations);
     } catch (error: any) {
-        console.error("[iterations] Error fetching iterations:", error);
+        log.error(LOG_CATEGORY, "[iterations] Error fetching iterations", {
+            requestId,
+            sessionId,
+            errorMessage: error instanceof Error ? error.message : String(error),
+        });
         return NextResponse.json(
             {
                 error: "Failed to fetch iterations",
@@ -186,4 +221,3 @@ export async function GET(
         );
     }
 }
-

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import OpenAI from "openai";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.INTERVIEWS;
 
 export async function POST(request: Request) {
+  const requestId = request.headers.get("x-request-id");
   try {
     const formData = await request.formData();
     const audioFile = formData.get("audio") as File;
@@ -28,11 +33,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ text: transcription.text });
   } catch (error) {
-    console.error("[Transcribe API] Error:", error);
+    log.error(LOG_CATEGORY, "[Transcribe API] Error", {
+      requestId,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Transcription failed" },
       { status: 500 }
     );
   }
 }
-

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.INTERVIEWS;
 
 export async function POST(request: Request) {
+  const requestId = request.headers.get("x-request-id");
   try {
     const { text } = await request.json();
 
@@ -48,11 +53,13 @@ export async function POST(request: Request) {
       headers: { "Content-Type": "audio/mpeg" },
     });
   } catch (error) {
-    console.error("[TTS API] Error:", error);
+    log.error(LOG_CATEGORY, "[TTS API] Error", {
+      requestId,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "TTS failed" },
       { status: 500 }
     );
   }
 }
-

--- a/app/test/external-tool-conversation/page.tsx
+++ b/app/test/external-tool-conversation/page.tsx
@@ -2,6 +2,10 @@
 
 import { useState } from "react";
 import OpenAI from "openai";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
+
+const LOG_CATEGORY = LOG_CATEGORIES.INTERVIEW_UI;
 
 interface Message {
   role: "user" | "assistant";
@@ -142,7 +146,10 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
         readyToEvaluate: false,
       });
     } catch (error) {
-      console.error("Error:", error);
+      log.error(LOG_CATEGORY, "OpenAI request failed", {
+        pasteEvaluationId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       alert("Error communicating with OpenAI");
     } finally {
       setIsLoading(false);
@@ -202,7 +209,10 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
           // Remove CONTROL line from displayed text
           aiText = response.replace(/CONTROL:\s*\{[\s\S]*?\}\s*\n?/, "").trim();
         } catch (e) {
-          console.error("Failed to parse CONTROL:", e);
+          log.warn(LOG_CATEGORY, "Failed to parse CONTROL", {
+            pasteEvaluationId,
+            errorMessage: e instanceof Error ? e.message : String(e),
+          });
         }
       }
 
@@ -243,10 +253,17 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
               understandingLevel: score.understandingLevel,
             };
             setQuestionScores(prev => [...prev, newScore]);
-            console.log("Question score:", newScore);
+            log.debug(LOG_CATEGORY, "Question score recorded", {
+              pasteEvaluationId,
+              score: newScore.score,
+              understandingLevel: newScore.understandingLevel,
+            });
           }
         } catch (e) {
-          console.error("Failed to score Q&A:", e);
+          log.error(LOG_CATEGORY, "Failed to score Q&A", {
+            pasteEvaluationId,
+            errorMessage: e instanceof Error ? e.message : String(e),
+          });
         }
       }
 
@@ -255,7 +272,10 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
         await triggerFinalEvaluation(finalMessages);
       }
     } catch (error) {
-      console.error("Error:", error);
+      log.error(LOG_CATEGORY, "OpenAI follow-up failed", {
+        pasteEvaluationId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       alert("Error communicating with OpenAI");
     } finally {
       setIsLoading(false);
@@ -283,7 +303,10 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
       
       setFinalEvaluation(evaluation);
     } catch (error) {
-      console.error("Error aggregating evaluation:", error);
+      log.error(LOG_CATEGORY, "Error aggregating evaluation", {
+        pasteEvaluationId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
     }
   };
 
@@ -523,4 +546,3 @@ Ask ONE short, relevant question (1-2 sentences) to understand if they comprehen
     </div>
   );
 }
-

--- a/server/db-scripts/add-default-scoring-configs.ts
+++ b/server/db-scripts/add-default-scoring-configs.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env tsx
 
 import { PrismaClient } from "@prisma/client";
+import { randomUUID } from "node:crypto";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
 
 process.env.DATABASE_URL = process.env.DEV_DATABASE_URL || process.env.DATABASE_URL;
 
 const prisma = new PrismaClient();
+const LOG_CATEGORY = LOG_CATEGORIES.DB;
+const runId = randomUUID();
 
 async function addDefaultScoringConfigs() {
-    console.log("🔄 Adding default scoring configurations to jobs...");
+    log.info(LOG_CATEGORY, "Adding default scoring configurations to jobs", { runId });
 
     const jobsWithoutConfig = await prisma.job.findMany({
         where: {
@@ -19,7 +24,10 @@ async function addDefaultScoringConfigs() {
         },
     });
 
-    console.log(`📊 Found ${jobsWithoutConfig.length} jobs without scoring configuration`);
+    log.info(LOG_CATEGORY, "Found jobs without scoring configuration", {
+        runId,
+        jobCount: jobsWithoutConfig.length,
+    });
 
     for (const job of jobsWithoutConfig) {
         try {
@@ -31,17 +39,29 @@ async function addDefaultScoringConfigs() {
                     codingWeight: 50,
                 },
             });
-            console.log(`✅ Added scoring config for job: ${job.title}`);
+            log.info(LOG_CATEGORY, "Added scoring config for job", {
+                runId,
+                jobId: job.id,
+                jobTitle: job.title,
+            });
         } catch (error) {
-            console.error(`❌ Failed to add config for job ${job.title}:`, error);
+            log.error(LOG_CATEGORY, "Failed to add config for job", {
+                runId,
+                jobId: job.id,
+                jobTitle: job.title,
+                errorMessage: error instanceof Error ? error.message : String(error),
+            });
         }
     }
 
-    console.log("\n✅ Done!");
+    log.info(LOG_CATEGORY, "Default scoring configurations complete", { runId });
     await prisma.$disconnect();
 }
 
 addDefaultScoringConfigs().catch((error) => {
-    console.error("Fatal error:", error);
+    log.error(LOG_CATEGORY, "Fatal error adding default scoring configs", {
+        runId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+    });
     process.exit(1);
 });

--- a/server/db-scripts/backfill-final-scores.ts
+++ b/server/db-scripts/backfill-final-scores.ts
@@ -1,15 +1,20 @@
 #!/usr/bin/env tsx
 
 import { PrismaClient } from "@prisma/client";
+import { randomUUID } from "node:crypto";
+import { log } from "app/shared/services";
+import { LOG_CATEGORIES } from "app/shared/services/logger.config";
 import { calculateScore, type RawScores, type WorkstyleMetrics } from "../../app/shared/utils/calculateScore";
 
 // Use DEV_DATABASE_URL (orange-tree) as user confirmed
 process.env.DATABASE_URL = process.env.DEV_DATABASE_URL || process.env.DATABASE_URL;
 
 const prisma = new PrismaClient();
+const LOG_CATEGORY = LOG_CATEGORIES.DB;
+const runId = randomUUID();
 
 async function backfillFinalScores() {
-    console.log("🔄 Starting final score backfill...");
+    log.info(LOG_CATEGORY, "Starting final score backfill", { runId });
 
     const sessions = await prisma.interviewSession.findMany({
         where: {
@@ -38,7 +43,10 @@ async function backfillFinalScores() {
         },
     });
 
-    console.log(`📊 Found ${sessions.length} sessions without finalScore`);
+    log.info(LOG_CATEGORY, "Found sessions without finalScore", {
+        runId,
+        sessionCount: sessions.length,
+    });
 
     let successCount = 0;
     let failCount = 0;
@@ -48,17 +56,21 @@ async function backfillFinalScores() {
             const { telemetryData, application } = session;
             const job = application.job;
 
-            console.log(`🔍 Checking session ${session.id}:`, {
+            log.debug(LOG_CATEGORY, "Checking session for backfill", {
+                runId,
+                sessionId: session.id,
                 jobId: job.id,
-                jobTitle: job.title,
-                hasBackgroundSummary: !!telemetryData?.backgroundSummary,
-                hasCodingSummary: !!telemetryData?.codingSummary,
-                hasScoringConfig: !!job.scoringConfiguration,
+                hasBackgroundSummary: Boolean(telemetryData?.backgroundSummary),
+                hasCodingSummary: Boolean(telemetryData?.codingSummary),
+                hasScoringConfig: Boolean(job.scoringConfiguration),
                 scoringConfigId: job.scoringConfiguration?.id,
             });
 
             if (!telemetryData?.backgroundSummary || !telemetryData?.codingSummary || !job.scoringConfiguration) {
-                console.log(`⏭️  Skipping session ${session.id} - missing required data`);
+                log.debug(LOG_CATEGORY, "Skipping session - missing required data", {
+                    runId,
+                    sessionId: session.id,
+                });
                 continue;
             }
 
@@ -102,17 +114,12 @@ async function backfillFinalScores() {
                 aiAssistAccountabilityScore: avgAccountabilityScore
             };
 
-            console.log(`📊 Score calculation inputs for ${session.id}:`, {
-                experienceScores,
-                categoryScores,
-                workstyleMetrics,
-                scoringConfig: job.scoringConfiguration,
-            });
-
             const result = calculateScore(rawScores, workstyleMetrics, job.scoringConfiguration as any);
             const finalScore = Math.round(result.finalScore);
 
-            console.log(`📊 Score calculation result:`, {
+            log.debug(LOG_CATEGORY, "Score calculation result", {
+                runId,
+                sessionId: session.id,
                 experienceScore: result.experienceScore,
                 codingScore: result.codingScore,
                 finalScore: result.finalScore,
@@ -124,22 +131,35 @@ async function backfillFinalScores() {
                 data: { finalScore },
             });
 
-            console.log(`✅ Session ${session.id}: finalScore = ${finalScore}`);
+            log.info(LOG_CATEGORY, "Session finalScore updated", {
+                runId,
+                sessionId: session.id,
+                finalScore,
+            });
             successCount++;
         } catch (error) {
-            console.error(`❌ Failed to process session ${session.id}:`, error);
+            log.error(LOG_CATEGORY, "Failed to process session", {
+                runId,
+                sessionId: session.id,
+                errorMessage: error instanceof Error ? error.message : String(error),
+            });
             failCount++;
         }
     }
 
-    console.log(`\n📈 Backfill complete:`);
-    console.log(`   ✅ Success: ${successCount}`);
-    console.log(`   ❌ Failed: ${failCount}`);
+    log.info(LOG_CATEGORY, "Backfill complete", {
+        runId,
+        successCount,
+        failCount,
+    });
 
     await prisma.$disconnect();
 }
 
 backfillFinalScores().catch((error) => {
-    console.error("Fatal error:", error);
+    log.error(LOG_CATEGORY, "Fatal error during backfill", {
+        runId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+    });
     process.exit(1);
 });

--- a/shared/services/backgroundInterview/useAnnouncementGeneration.ts
+++ b/shared/services/backgroundInterview/useAnnouncementGeneration.ts
@@ -21,12 +21,19 @@ interface AnnouncementResult {
  */
 export function useAnnouncementGeneration() {
   const generateAnnouncement = useCallback(async (jobTitle: string): Promise<AnnouncementResult> => {
+    const requestId = globalThis.crypto.randomUUID();
     try {
       const announcement = `Hi! Welcome to your ${jobTitle} interview`;
-      log.info(LOG_CATEGORY, "[announcement] Generated text:", announcement);
+      log.info(LOG_CATEGORY, "[announcement] Generated text", {
+        requestId,
+        jobTitle,
+        announcementLength: announcement.length,
+      });
 
       // Fetch TTS audio
-      log.info(LOG_CATEGORY, "[announcement] Generating TTS...");
+      log.info(LOG_CATEGORY, "[announcement] Generating TTS", {
+        requestId,
+      });
       let audioBlob: Blob | null = null;
 
       try {
@@ -39,17 +46,29 @@ export function useAnnouncementGeneration() {
         if (ttsResp.ok) {
           const audioBuffer = await ttsResp.arrayBuffer();
           audioBlob = new Blob([audioBuffer], { type: "audio/mpeg" });
-          log.info(LOG_CATEGORY, "[announcement] TTS generated successfully");
+          log.info(LOG_CATEGORY, "[announcement] TTS generated successfully", {
+            requestId,
+            audioBytes: audioBuffer.byteLength,
+          });
         } else {
-          console.warn("[announcement] TTS failed with status:", ttsResp.status);
+          log.warn(LOG_CATEGORY, "[announcement] TTS failed with status", {
+            requestId,
+            status: ttsResp.status,
+          });
         }
       } catch (err) {
-        console.warn("[announcement] Error calling TTS API:", err);
+        log.warn(LOG_CATEGORY, "[announcement] Error calling TTS API", {
+          requestId,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        });
       }
 
       return { text: announcement, audioBlob };
     } catch (error) {
-      log.error(LOG_CATEGORY, "[announcement] Unexpected error:", error);
+      log.error(LOG_CATEGORY, "[announcement] Unexpected error", {
+        requestId,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
   }, []);

--- a/shared/services/backgroundInterview/useBackgroundPreload.ts
+++ b/shared/services/backgroundInterview/useBackgroundPreload.ts
@@ -4,7 +4,7 @@
  * Stores preloaded data in Redux. Called during loading phase.
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
 import OpenAI from "openai";
 import { log } from "app/shared/services/logger";
@@ -28,6 +28,7 @@ const LOG_CATEGORY = LOG_CATEGORIES.BACKGROUND_INTERVIEW;
  */
 export function useBackgroundPreload() {
   const dispatch = useDispatch();
+  const preloadId = useMemo(() => globalThis.crypto.randomUUID(), []);
 
   const preload = useCallback(
     async (
@@ -39,7 +40,12 @@ export function useBackgroundPreload() {
       onExperienceCategoriesSet?: (categories: Array<{name: string; description: string; weight: number; example?: string}>) => void
     ) => {
       try {
-        log.info(LOG_CATEGORY, "[preload] Starting preload sequence...");
+        log.info(LOG_CATEGORY, "[preload] Starting preload sequence", {
+          preloadId,
+          jobId,
+          companyId,
+          sessionUserId,
+        });
 
         const parts = jobId.split("-");
         const companySlug = parts[0];
@@ -50,7 +56,12 @@ export function useBackgroundPreload() {
         }
 
         // Step 1: Create application for authenticated user
-        log.info(LOG_CATEGORY, "[preload] Creating application for authenticated user...");
+        log.info(LOG_CATEGORY, "[preload] Creating application for authenticated user", {
+          preloadId,
+          jobId,
+          companyId,
+          sessionUserId,
+        });
         const userId = sessionUserId;
         const appResp = await fetch(`/api/applications/create`, {
           method: "POST",
@@ -63,7 +74,12 @@ export function useBackgroundPreload() {
         const createdApplicationId = appData.application.id;
 
         // Step 2: Create interview session
-        log.info(LOG_CATEGORY, "[preload] Creating interview session...");
+        log.info(LOG_CATEGORY, "[preload] Creating interview session", {
+          preloadId,
+          jobId,
+          companyId,
+          sessionUserId,
+        });
         const session = await createInterviewSession({
           applicationId: createdApplicationId,
           companyId,
@@ -82,14 +98,25 @@ export function useBackgroundPreload() {
           const cached = localStorage.getItem(scriptCacheKey);
           if (cached) {
             scriptData = JSON.parse(cached);
-            log.info(LOG_CATEGORY, "[preload] Script loaded from cache");
+            log.info(LOG_CATEGORY, "[preload] Script loaded from cache", {
+              preloadId,
+              jobId,
+            });
           }
         } catch (err) {
-          console.warn("[preload] Failed to read script cache:", err);
+          log.warn(LOG_CATEGORY, "[preload] Failed to read script cache", {
+            preloadId,
+            jobId,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          });
         }
 
         if (!scriptData) {
-          log.info(LOG_CATEGORY, "[preload] Fetching script from API...");
+          log.info(LOG_CATEGORY, "[preload] Fetching script from API", {
+            preloadId,
+            jobId,
+            companyId,
+          });
           const scriptResp = await fetch(`/api/interviews/script?company=${companySlug}&role=${roleSlug}`);
           if (!scriptResp.ok) throw new Error("Failed to load interview script");
           scriptData = await scriptResp.json();
@@ -97,7 +124,11 @@ export function useBackgroundPreload() {
         }
 
         // Step 4: Generate first OpenAI question with intent
-        log.info(LOG_CATEGORY, "[preload] Generating first question...");
+        log.info(LOG_CATEGORY, "[preload] Generating first question", {
+          preloadId,
+          jobId,
+          companyId,
+        });
         const companyNameFromScript = scriptData.companyName || companySlug.charAt(0).toUpperCase() + companySlug.slice(1);
         const instruction = `Ask exactly: "${String(scriptData.backgroundQuestion)}"
 
@@ -125,7 +156,11 @@ Return JSON with format: {"question": "...", "evaluationIntent": "..."}`;
           firstQuestion = parsed.question || firstQuestionRaw;
           firstIntent = parsed.evaluationIntent || "";
         } catch (err) {
-          console.warn("[preload] Failed to parse JSON, using raw response");
+          log.warn(LOG_CATEGORY, "[preload] Failed to parse JSON, using raw response", {
+            preloadId,
+            jobId,
+            errorMessage: err instanceof Error ? err.message : String(err),
+          });
         }
 
         // Store preloaded data in Redux
@@ -165,10 +200,21 @@ Return JSON with format: {"question": "...", "evaluationIntent": "..."}`;
           dispatch(initializeCategoryStats({ categories: categoryNames }));
         }
 
-        log.info(LOG_CATEGORY, "[preload] Preload complete - data stored in Redux");
+        log.info(LOG_CATEGORY, "[preload] Preload complete - data stored in Redux", {
+          preloadId,
+          jobId,
+          companyId,
+          sessionId: sessId,
+        });
         return { success: true, scriptData, firstQuestion, companyNameFromScript };
       } catch (error) {
-        log.error(LOG_CATEGORY, "[preload] Preload failed:", error);
+        log.error(LOG_CATEGORY, "[preload] Preload failed", {
+          preloadId,
+          jobId,
+          companyId,
+          sessionUserId,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
         throw error;
       }
     },

--- a/shared/services/backgroundInterview/useSoundPreload.ts
+++ b/shared/services/backgroundInterview/useSoundPreload.ts
@@ -4,7 +4,7 @@
  * Returns refs to audio elements and ready flag.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { loadAndCacheSoundEffect } from "@/shared/utils/audioCache";
 import { log } from "app/shared/services/logger";
 import { LOG_CATEGORIES } from "app/shared/services/logger.config";
@@ -18,6 +18,7 @@ export function useSoundPreload() {
   const clickSoundRef = useRef<HTMLAudioElement | null>(null);
   const startSoundRef = useRef<HTMLAudioElement | null>(null);
   const [soundsReady, setSoundsReady] = useState(false);
+  const preloadId = useMemo(() => globalThis.crypto.randomUUID(), []);
 
   useEffect(() => {
     // Skip if already loaded
@@ -26,7 +27,10 @@ export function useSoundPreload() {
       return;
     }
 
-    log.info(LOG_CATEGORY, "[sounds] Starting preload...");
+    log.info(LOG_CATEGORY, "[sounds] Starting preload", {
+      preloadId,
+      soundKeys: ["click-button", "start-interview"],
+    });
     Promise.all([
       loadAndCacheSoundEffect("/sounds/click-button.mp3", "click-button"),
       loadAndCacheSoundEffect("/sounds/start-interview.mp3", "start-interview"),
@@ -35,10 +39,16 @@ export function useSoundPreload() {
         clickSoundRef.current = clickSound;
         startSoundRef.current = startSound;
         setSoundsReady(true);
-        log.info(LOG_CATEGORY, "[sounds] Preload complete");
+        log.info(LOG_CATEGORY, "[sounds] Preload complete", {
+          preloadId,
+          soundKeys: ["click-button", "start-interview"],
+        });
       })
       .catch((err) => {
-        console.error("[sounds] Preload failed:", err);
+        log.error(LOG_CATEGORY, "[sounds] Preload failed", {
+          preloadId,
+          errorMessage: err instanceof Error ? err.message : String(err),
+        });
         setSoundsReady(true); // Continue anyway
       });
   }, []);

--- a/tests/api-logging-runtime.test.ts
+++ b/tests/api-logging-runtime.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Runtime logging assertions for API routes with correlation context.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type LogMock = {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+};
+
+const createLogMock = (): LogMock => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+});
+
+const createRequest = (body: unknown, headers?: Record<string, string>) =>
+  new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  });
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("API logging runtime assertions", () => {
+  it("logs errors with requestId in chat route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("openai", () => ({
+      default: class OpenAI {
+        chat = { completions: { create: vi.fn().mockRejectedValue(new Error("boom")) } };
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/chat/route");
+    const request = createRequest({ persona: "persona", instruction: "hi" }, { "x-request-id": "req-1" });
+    await POST(request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-1" });
+  });
+
+  it("logs errors with requestId in evaluate-output route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("openai", () => ({
+      default: class OpenAI {
+        chat = { completions: { create: vi.fn().mockRejectedValue(new Error("boom")) } };
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/evaluate-output/route");
+    const request = createRequest({
+      actualOutput: "1",
+      expectedOutput: "1",
+      codingTask: "task",
+      codeSnapshot: "code",
+    }, { "x-request-id": "req-2" });
+    await POST(request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-2" });
+  });
+
+  it("logs errors with requestId in evaluate-answer-fast route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("lib/prisma", () => ({
+      default: {
+        interviewSession: { findUnique: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/evaluate-answer-fast/route");
+    const request = createRequest({
+      sessionId: "session-1",
+      question: "q",
+      answer: "a",
+      experienceCategories: [{ name: "Cat" }],
+      currentCounts: [{ categoryName: "Cat", count: 0, avgStrength: 0, dontKnowCount: 0 }],
+      excludedTopics: [],
+    }, { "x-request-id": "req-3" });
+    await POST(request as Request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-3" });
+  });
+
+  it("logs errors with requestId in evaluate-answer route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("lib/prisma", () => ({
+      default: {
+        interviewSession: { findUnique: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/evaluate-answer/route");
+    const request = createRequest({
+      sessionId: "session-2",
+      question: "q",
+      answer: "a",
+      timestamp: new Date().toISOString(),
+      experienceCategories: [{ name: "Cat", description: "desc" }],
+      currentCounts: [{ categoryName: "Cat", count: 0, avgStrength: 0 }],
+    }, { "x-request-id": "req-4" });
+    await POST(request as Request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-4" });
+  });
+
+  it("logs errors with requestId in generate-profile-story route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("lib/prisma", () => ({
+      default: {
+        interviewSession: { findUnique: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/generate-profile-story/route");
+    const request = createRequest({ sessionId: "session-3" }, { "x-request-id": "req-5" });
+    await POST(request as Request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-5" });
+  });
+
+  it("logs errors with requestId in iterations POST route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("app/shared/services/prisma", () => ({
+      prisma: {
+        iteration: { create: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+
+    const { POST } = await import("app/api/interviews/session/[sessionId]/iterations/route");
+    const request = createRequest({
+      timestamp: new Date().toISOString(),
+      codeSnapshot: "code",
+      actualOutput: "1",
+      expectedOutput: "1",
+      evaluation: "correct",
+      reasoning: "ok",
+      matchPercentage: 100,
+      caption: "cap",
+    }, { "x-request-id": "req-6" });
+    await POST(request as Request, { params: Promise.resolve({ sessionId: "session-4" }) });
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-6" });
+  });
+
+  it("logs errors with requestId in iterations GET route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("app/shared/services/prisma", () => ({
+      prisma: {
+        iteration: { findMany: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+
+    const { GET } = await import("app/api/interviews/session/[sessionId]/iterations/route");
+    const request = new Request("http://localhost", { headers: { "x-request-id": "req-7" } });
+    await GET(request as Request, { params: Promise.resolve({ sessionId: "session-5" }) });
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-7" });
+  });
+
+  it("logs errors with requestId in transcribe route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+
+    const { POST } = await import("app/api/transcribe/route");
+    const request = {
+      headers: new Headers({ "x-request-id": "req-8" }),
+      formData: async () => {
+        throw new Error("boom");
+      },
+    } as unknown as Request;
+
+    await POST(request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-8" });
+  });
+
+  it("logs errors with requestId in tts route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+
+    const { POST } = await import("app/api/tts/route");
+    const request = new Request("http://localhost", {
+      method: "POST",
+      body: "{",
+      headers: { "x-request-id": "req-9" },
+    });
+    await POST(request);
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-9" });
+  });
+
+  it("logs errors with requestId in candidate basic route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("app/shared/services/auth", () => ({ authOptions: {} }));
+    vi.doMock("next-auth/next", () => ({ getServerSession: vi.fn().mockResolvedValue({ user: { id: "user" } }) }));
+    vi.doMock("@prisma/client", () => ({
+      PrismaClient: class PrismaClient {
+        user = { findUnique: vi.fn().mockRejectedValue(new Error("boom")) };
+      },
+    }));
+
+    const { GET } = await import("app/api/candidates/[id]/basic/route");
+    const request = new Request("http://localhost?skip-auth=true", { headers: { "x-request-id": "req-10" } });
+    await GET(request as Request, { params: Promise.resolve({ id: "candidate-1" }) });
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-10" });
+  });
+
+  it("logs errors with requestId in applicants route", async () => {
+    const log = createLogMock();
+    vi.doMock("app/shared/services", () => ({ log }));
+    vi.doMock("next-auth", () => ({
+      getServerSession: vi.fn().mockResolvedValue({ user: { id: "user", role: "ADMIN" } }),
+    }));
+    vi.doMock("lib/prisma", () => ({
+      default: {
+        job: { findUnique: vi.fn().mockRejectedValue(new Error("boom")) },
+      },
+    }));
+    vi.doMock("app/shared/services/server", () => ({
+      authOptions: {},
+      getCached: vi.fn().mockResolvedValue(null),
+      setCached: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    const { GET } = await import("app/api/company/jobs/[jobId]/applicants/route");
+    const request = new Request("http://localhost", { headers: { "x-request-id": "req-11" } });
+    await GET(request as Request, { params: Promise.resolve({ jobId: "job-1" }) });
+
+    expect(log.error).toHaveBeenCalled();
+    const payload = log.error.mock.calls[0]?.[2] ?? log.error.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({ requestId: "req-11" });
+  });
+});

--- a/tests/observability-logging.test.ts
+++ b/tests/observability-logging.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Verifies logger usage and correlation context across files that replaced console logging.
+ */
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const filesWithContext = [
+  {
+    file: "app/(features)/company-dashboard/ApplicantsByJob.tsx",
+    requiredPatterns: ["log.error", "errorMessage"],
+  },
+  {
+    file: "app/(features)/cps/components/EvidenceReel.tsx",
+    requiredPatterns: ["log.warn", "errorMessage"],
+  },
+  {
+    file: "app/(features)/cps/page.tsx",
+    requiredPatterns: ["log.info", "errorMessage"],
+  },
+  {
+    file: "app/api/candidates/[id]/basic/route.ts",
+    requiredPatterns: ["requestId", "log.error"],
+  },
+  {
+    file: "app/api/company/jobs/[jobId]/applicants/route.ts",
+    requiredPatterns: ["requestId", "log.error"],
+  },
+  {
+    file: "app/api/interviews/chat/route.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "app/api/interviews/evaluate-answer-fast/route.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "app/api/interviews/evaluate-answer/route.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "app/api/interviews/evaluate-output/route.ts",
+    requiredPatterns: ["requestId", "log.error"],
+  },
+  {
+    file: "app/api/interviews/generate-profile-story/route.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "app/api/interviews/session/[sessionId]/iterations/route.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "app/api/transcribe/route.ts",
+    requiredPatterns: ["requestId", "log.error"],
+  },
+  {
+    file: "app/api/tts/route.ts",
+    requiredPatterns: ["requestId", "log.error"],
+  },
+  {
+    file: "app/test/external-tool-conversation/page.tsx",
+    requiredPatterns: ["log.error", "log.warn"],
+  },
+  {
+    file: "server/db-scripts/add-default-scoring-configs.ts",
+    requiredPatterns: ["runId", "log.info", "log.error"],
+  },
+  {
+    file: "server/db-scripts/backfill-final-scores.ts",
+    requiredPatterns: ["runId", "log.info", "log.error"],
+  },
+  {
+    file: "shared/services/backgroundInterview/useAnnouncementGeneration.ts",
+    requiredPatterns: ["requestId", "log.info", "log.error"],
+  },
+  {
+    file: "shared/services/backgroundInterview/useBackgroundPreload.ts",
+    requiredPatterns: ["preloadId", "log.info", "log.error"],
+  },
+  {
+    file: "shared/services/backgroundInterview/useSoundPreload.ts",
+    requiredPatterns: ["preloadId", "log.info", "log.error"],
+  },
+];
+
+describe("observability logging replacements", () => {
+  it("removes console usage and keeps correlation context", () => {
+    for (const entry of filesWithContext) {
+      const filePath = path.join(process.cwd(), entry.file);
+      const content = fs.readFileSync(filePath, "utf8");
+      expect(content).not.toMatch(/\bconsole\./);
+      for (const pattern of entry.requiredPatterns) {
+        expect(content).toContain(pattern);
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `console.*` calls with structured `log` usage to ensure consistent observability and include correlation fields (requestId / sessionId / preloadId / runId) and error metadata.  
- Strengthen test coverage so logging changes are verifiable both statically (file tokens) and at runtime (captured logger calls).  
- Fix a scoping bug that could cause `ReferenceError` for `sessionId` in evaluation routes so error logging always includes the session context.

### Description
- Replaced `console.log`/`console.warn`/`console.error` across frontend, API, and server scripts with `log.info`/`log.warn`/`log.error` and added `LOG_CATEGORIES` usage and structured payloads including `requestId`, `sessionId`, `preloadId`, `runId`, and `errorMessage` where applicable.  
- Removed noisy debug prints and converted them to structured `log` calls in files such as CPS UI components, interview APIs (`chat`, `evaluate-answer`, `evaluate-answer-fast`, `evaluate-output`, `generate-profile-story`, `iterations`, `transcribe`, `tts`), company/candidate APIs, and DB backfill scripts.  
- Added a runtime Vitest test `tests/api-logging-runtime.test.ts` that mocks the shared `log` and imports API route handlers to assert error paths call `log.error` with a payload containing `requestId`.  
- Strengthened static assertions in `tests/observability-logging.test.ts` to verify that modified files do not contain `console.` usage and contain required logging tokens per file.  
- Fixed `sessionId` scoping in `app/api/interviews/evaluate-answer/route.ts` and `app/api/interviews/evaluate-answer-fast/route.ts` so `sessionId` is available for logging in catch/err paths, and added small test scaffolding mocks (e.g. `authOptions`) used by runtime tests.

### Testing
- Ran the project's test suite with `pnpm test` (Vitest) which executed the static and runtime logging tests.  
- Final automated test result: all tests passed (`2` test files, `12` tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad7a6e334832b837d09aad76cf85f)