### PR TITLE
Add voice recording and transcription to chat panel

### DIFF
--- a/app/(features)/interview/components/InterviewIDE.tsx
+++ b/app/(features)/interview/components/InterviewIDE.tsx
@@ -61,6 +61,7 @@ interface InterviewerContentProps {
     setJobCategories: (categories: Array<{name: string; description: string; weight: number}> | null) => void;
     evaluationThrottleMs: number;
     setEvaluationThrottleMs: (ms: number) => void;
+    micStream?: MediaStream | null;
 }
 
 /**
@@ -81,6 +82,7 @@ const InterviewerContent: React.FC<InterviewerContentProps> = ({
     setJobCategories,
     evaluationThrottleMs,
     setEvaluationThrottleMs,
+    micStream,
 }) => {
     const {
         state,
@@ -1358,6 +1360,7 @@ const InterviewerContent: React.FC<InterviewerContentProps> = ({
                             }}
                             interviewSessionId={interviewSessionId}
                             userId={reduxUserId || undefined}
+                            micStream={micStream}
                         />
                     </Panel>
                 </PanelGroup>
@@ -1378,7 +1381,7 @@ const InterviewerContent: React.FC<InterviewerContentProps> = ({
 /**
  * Wrapper component that renders both the main content and debug panel
  */
-const InterviewIDEWithDebug = () => {
+const InterviewIDEWithDebug = ({ micStream }: InterviewIDEProps) => {
     const { isDebugVisible } = useDebug();
     const isDebugModeEnabled = process.env.NEXT_PUBLIC_DEBUG_MODE === "true";
     const [evaluationDebugData, setEvaluationDebugData] = useState<any>(null);
@@ -1393,7 +1396,7 @@ const InterviewIDEWithDebug = () => {
         }
         return Number(envValue);
     });
-    
+
     const onTestEvaluationReady = useCallback((callback: () => void) => {
         setTestEvaluationCallback(() => callback);
     }, []);
@@ -1406,7 +1409,7 @@ const InterviewIDEWithDebug = () => {
     
     return (
         <div>
-            <InterviewerContent 
+            <InterviewerContent
                 isDebugVisible={isDebugVisible}
                 evaluationDebugData={evaluationDebugData}
                 setEvaluationDebugData={setEvaluationDebugData}
@@ -1420,6 +1423,7 @@ const InterviewIDEWithDebug = () => {
                 setJobCategories={setJobCategories}
                 evaluationThrottleMs={evaluationThrottleMs}
                 setEvaluationThrottleMs={setEvaluationThrottleMs}
+                micStream={micStream}
             />
             
             {/* Debug Panel - below IDE in document flow, scroll down to see it */}
@@ -1442,10 +1446,14 @@ const InterviewIDEWithDebug = () => {
 /**
  * Root wrapper that provides interview context and renders the main content.
  */
-const InterviewIDE = () => {
+interface InterviewIDEProps {
+    micStream?: MediaStream | null;
+}
+
+const InterviewIDE = ({ micStream }: InterviewIDEProps) => {
     return (
         <InterviewProvider>
-            <InterviewIDEWithDebug />
+            <InterviewIDEWithDebug micStream={micStream} />
         </InterviewProvider>
     );
 };

--- a/app/(features)/interview/components/RightPanel.tsx
+++ b/app/(features)/interview/components/RightPanel.tsx
@@ -27,6 +27,7 @@ interface RightPanelProps {
     setInputLocked?: (locked: boolean) => void;
     onHighlightPastedCode?: (pastedCode: string) => void;
     interviewSessionId?: string | null;
+    micStream?: MediaStream | null;
 }
 
 const RightPanel: React.FC<RightPanelProps> = ({
@@ -52,6 +53,7 @@ const RightPanel: React.FC<RightPanelProps> = ({
     codingDurationSeconds,
     setInputLocked,
     interviewSessionId,
+    micStream,
 }) => {
     return (
         <div className="h-full flex flex-col border-t">
@@ -98,6 +100,7 @@ const RightPanel: React.FC<RightPanelProps> = ({
                     isInputDisabled={isTextInputLocked}
                     isInterviewActive={isInterviewActive}
                     isAgentConnected={isAgentConnected}
+                    micStream={micStream}
                 />
             </div>
         </div>

--- a/app/(features)/interview/components/chat/ChatPanel.tsx
+++ b/app/(features)/interview/components/chat/ChatPanel.tsx
@@ -26,9 +26,10 @@ interface ChatPanelProps {
     isInputDisabled?: boolean;
     isInterviewActive?: boolean;
     isAgentConnected?: boolean;
+    micStream?: MediaStream | null;
 }
 
-const ChatPanel = ({ micMuted = false, onToggleMicMute, onSendText, isInputDisabled = false, isInterviewActive = false, isAgentConnected = false }: ChatPanelProps) => {
+const ChatPanel = ({ micMuted = false, onToggleMicMute, onSendText, isInputDisabled = false, isInterviewActive = false, isAgentConnected = false, micStream }: ChatPanelProps) => {
     const messages = useSelector((s: RootState) => s.coding.messages);
     const transcriptions: TranscriptionMessage[] = messages.map((m) => ({
         id: m.id,
@@ -43,8 +44,12 @@ const ChatPanel = ({ micMuted = false, onToggleMicMute, onSendText, isInputDisab
     const [activePasteEvalId, setActivePasteEvalId] = useState<string | undefined>();
     const [showQuickReply, setShowQuickReply] = useState(false);
     const [buttonClicked, setButtonClicked] = useState(false);
+    const [isVoiceRecording, setIsVoiceRecording] = useState(false);
+    const [isTranscribing, setIsTranscribing] = useState(false);
     const messagesContainerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLTextAreaElement>(null);
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+    const audioChunksRef = useRef<Blob[]>([]);
 
     // Track active paste evaluation changes
     useEffect(() => {
@@ -83,6 +88,61 @@ const ChatPanel = ({ micMuted = false, onToggleMicMute, onSendText, isInputDisab
             });
         }
     }, [messages.length, isPendingReply]);
+
+    const startVoiceRecording = async () => {
+        if (!micStream) return;
+
+        try {
+            const mimeType = "audio/webm;codecs=opus";
+            const mediaRecorder = new MediaRecorder(micStream, { mimeType });
+            mediaRecorderRef.current = mediaRecorder;
+            audioChunksRef.current = [];
+
+            mediaRecorder.ondataavailable = (event) => {
+                if (event.data.size > 0) {
+                    audioChunksRef.current.push(event.data);
+                }
+            };
+
+            mediaRecorder.onstop = async () => {
+                setIsTranscribing(true);
+                const audioBlob = new Blob(audioChunksRef.current, { type: mimeType });
+
+                const formData = new FormData();
+                formData.append("audio", audioBlob, "recording.webm");
+
+                try {
+                    const response = await fetch("/api/transcribe", {
+                        method: "POST",
+                        body: formData,
+                    });
+
+                    const { text } = await response.json();
+                    if (inputRef.current) {
+                        const currentText = inputRef.current.value;
+                        inputRef.current.value = currentText ? `${currentText} ${text}` : text;
+                        inputRef.current.focus();
+                    }
+                } catch (error) {
+                    log.error(LOG_CATEGORY, "Transcription error:", error);
+                } finally {
+                    setIsTranscribing(false);
+                }
+            };
+
+            mediaRecorder.start();
+            setIsVoiceRecording(true);
+        } catch (error) {
+            log.error(LOG_CATEGORY, "Failed to start recording:", error);
+        }
+    };
+
+    const stopVoiceRecording = () => {
+        if (mediaRecorderRef.current && isVoiceRecording) {
+            mediaRecorderRef.current.stop();
+            setIsVoiceRecording(false);
+        }
+    };
 
     return (
         <div className="h-full flex flex-col bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700">
@@ -241,13 +301,38 @@ const ChatPanel = ({ micMuted = false, onToggleMicMute, onSendText, isInputDisab
                                 }
                             }}
                         />
-                        <button
-                            type="submit"
-                            className="px-3 py-2 text-sm rounded-md bg-sfinx-purple text-white hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
-                            disabled={isInputDisabled}
-                        >
-                            Send
-                        </button>
+                        <div className="flex gap-1">
+                            <button
+                                type="button"
+                                onClick={isVoiceRecording ? stopVoiceRecording : startVoiceRecording}
+                                disabled={isInputDisabled || !micStream}
+                                className={`p-2 rounded-md transition-all duration-200 ${
+                                    isVoiceRecording
+                                        ? "bg-red-100 hover:bg-red-200 dark:bg-red-900/20 dark:hover:bg-red-900/30"
+                                        : isTranscribing
+                                        ? "bg-blue-100 dark:bg-blue-900/20"
+                                        : "hover:bg-gray-200 dark:hover:bg-gray-700"
+                                } disabled:opacity-50 disabled:cursor-not-allowed`}
+                                title={isVoiceRecording ? "Stop recording" : isTranscribing ? "Transcribing..." : "Start recording"}
+                            >
+                                {isTranscribing ? (
+                                    <div className="w-5 h-5 flex items-center justify-center">
+                                        <div className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-pulse"></div>
+                                    </div>
+                                ) : isVoiceRecording ? (
+                                    <Mic className="w-5 h-5 text-red-500 animate-pulse" />
+                                ) : (
+                                    <Mic className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+                                )}
+                            </button>
+                            <button
+                                type="submit"
+                                className="px-3 py-2 text-sm rounded-md bg-sfinx-purple text-white hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                                disabled={isInputDisabled}
+                            >
+                                Send
+                            </button>
+                        </div>
                     </form>
                 ) : (
                     <div className="flex items-center justify-between text-xs text-gray-600 dark:text-gray-400">

--- a/app/(features)/interview/page.tsx
+++ b/app/(features)/interview/page.tsx
@@ -853,7 +853,7 @@ function InterviewPageContent() {
   if (stage === "coding" && showCodingIDE) {
     return (
       <InterviewRecordingProvider value={recordingControls}>
-        <InterviewIDE />
+        <InterviewIDE micStream={micStream} />
       </InterviewRecordingProvider>
     );
   }


### PR DESCRIPTION
## Summary
This PR adds voice recording and transcription capabilities to the chat panel, allowing users to record audio messages that are automatically transcribed and inserted into the text input field.

## Key Changes
- **Voice Recording UI**: Added a microphone button next to the send button that toggles between recording and stopped states with visual feedback (red pulsing icon while recording, blue pulsing dot while transcribing)
- **Audio Capture**: Implemented `startVoiceRecording()` and `stopVoiceRecording()` functions that use the MediaRecorder API to capture audio from the provided `micStream`
- **Transcription Integration**: Audio recordings are sent to `/api/transcribe` endpoint and the resulting text is automatically appended to the chat input field
- **Props Threading**: Passed `micStream` prop through the component hierarchy:
  - `InterviewIDE` → `InterviewIDEWithDebug` → `InterviewerContent` → `RightPanel` → `ChatPanel`
- **State Management**: Added `isVoiceRecording` and `isTranscribing` states to track recording and transcription progress
- **Error Handling**: Added error logging for recording and transcription failures

## Implementation Details
- Uses WebM/Opus codec for audio recording (`audio/webm;codecs=opus`)
- Audio chunks are collected in `audioChunksRef` and combined into a single Blob on stop
- Transcription is disabled when `micStream` is not available or input is locked
- Visual states clearly indicate: idle (gray mic), recording (red pulsing mic), and transcribing (blue pulsing dot)
- Minor formatting cleanup (trailing whitespace removal)

https://claude.ai/code/session_019SeGCAFtvkmS6UHQTej3xs