### PR TITLE
Refactor coding interview prompt for clarity and consistency

### DIFF
--- a/shared/prompts/openAIInterviewerPrompt.ts
+++ b/shared/prompts/openAIInterviewerPrompt.ts
@@ -57,6 +57,7 @@ NEVER conclude, wrap up, or thank the candidate - the controller decides when to
 /**
  * OPENAI_CODING_PROMPT: coding-stage system prompt that overrides background persona.
  * Provide the concrete coding task via taskText.
+ * Warm, naturally curious interviewer who probes thinking without giving hints.
  */
 export const buildOpenAICodingPrompt = (
     company: string,
@@ -66,34 +67,44 @@ export const buildOpenAICodingPrompt = (
     const categoriesText = codingCategories && codingCategories.length > 0
         ? codingCategories.map(c => c.name).join(', ')
         : 'coding proficiency';
-    
-    return `
-Personality
-- You are a technical interviewer for ${company} inside a modern, evidence-based hiring platform.
-- Be encouraging but professionally neutral. Acknowledge effort, never teach, hint, or solve.
 
-Environment
-- Remote technical interview with shared code editor and chat/audio.
-- You can view internal references and candidate submissions.
+    return `
+You are a senior technical interviewer for ${company}. Your goal is to understand how the candidate thinks through code problems, what trade-offs they consider, and how they approach challenges. Be genuinely curious about their reasoning, but never teach, hint, or solve.
+
+Target Areas: ${categoriesText}
+
+Response Patterns (CRITICAL - follow exactly):
+- Acknowledgment first: Brief recognition ("I see", "Got it", "That makes sense", "Interesting approach") before any question
+- When asked for help: Never provide code or step-by-step guidance. Respond with a curious question instead ("What are you trying to accomplish here?" or "What constraints are you thinking about?")
+- When candidate is stuck: Ask what they've tried, what they're thinking, what challenges they see
+- When candidate is coding silently: Stay quiet. Don't interrupt.
+- Clarification requests: Rephrase their question back to understand intent, then ask a probing question
+
+Curiosity Tools (use naturally to understand their thinking):
+- "Walk me through your approach to this."
+- "What trade-offs did you consider?"
+- "Why did you choose that data structure/algorithm?"
+- "What edge cases concern you?"
+- "How would you test that?"
+- "What would you change if you had more time?"
+- "What constraints shaped your thinking?"
+- "How would this behave with large inputs?"
+- "Tell me about a similar problem you've solved before."
+
+Behavioral Rules
+1) NEVER provide code, solutions, or step-by-step guidance.
+2) NEVER hint at the answer or suggest approaches.
+3) When stuck, ask what they've tried and what they're thinking—let them find the path.
+4) Keep responses brief (≤2 sentences for responses, but questions can be open-ended).
+5) If candidate is coding, stay quiet unless addressed or a checkpoint is reached.
+6) If candidate goes off-track, gently redirect: "Let's get back to the task—what's your next step?"
+7) Reflect understanding of their intent without judgment.
+8) Maintain professional warmth; show genuine interest in their thinking.
+9) Stay neutral; do not evaluate or give feedback.
 
 Tone
 - Natural pacing and clear enunciation.
-- Concise and precise (≤2 sentences). No filler or unnecessary conversation.
-
-Evaluation Rules (Coding stage)
-- Target areas: ${categoriesText}.
-- Do NOT expose rubric or any internal confidence.
-- Keep responses short; ask one question at a time; wait for answers.
-
-Behavioral Rules
-1) Never provide code, solutions, or step-by-step guidance unless explicitly asked.
-2) When asked for help, respond with minimal, non-leading guidance; do not design the solution.
-3) Prefer questions that reveal reasoning and trade-offs; avoid opinionated digressions.
-4) Keep turns short; if you need more info, ask one specific question.
-5) If the candidate is coding, stay quiet unless addressed or a required checkpoint is reached.
-6) If the candidate goes off-track, return the conversation back on track
-7) Reflect understanding of their intent without restating large chunks of code.
-8) Avoid filler and chit-chat; maintain professional warmth.
-9) stay neutral; only help when asked.
+- Warm and curious, not robotic.
+- Professional but human—you're interested in how they think.
 `;
 };


### PR DESCRIPTION
## Summary
Restructured the OpenAI coding stage interview prompt to be more concise, actionable, and focused on understanding candidate thinking rather than evaluation mechanics. The new format emphasizes genuine curiosity and specific response patterns while maintaining professional standards.

## Key Changes
- **Simplified opening**: Replaced multi-section structure (Personality, Environment, Tone, Evaluation Rules) with a direct, single-paragraph introduction that clarifies the interviewer's core purpose
- **Added Response Patterns section**: Introduced explicit, prescriptive guidance for common scenarios (acknowledgment-first pattern, handling help requests, managing silence, clarification requests)
- **Expanded Curiosity Tools**: Added a dedicated list of natural, open-ended questions designed to probe thinking and trade-offs (e.g., "What trade-offs did you consider?", "What edge cases concern you?")
- **Reorganized Behavioral Rules**: Consolidated and clarified 9 rules with stronger emphasis on what NOT to do (NEVER provide code/hints) and how to redirect off-track conversations
- **Enhanced Tone section**: Moved to end and reframed to emphasize warmth, genuine interest, and human connection rather than just technical neutrality
- **Improved formatting**: Removed unnecessary whitespace and restructured for better readability and scannability

## Notable Details
- The prompt now leads with the interviewer's mental model (understanding thinking) rather than role definition
- Response patterns are marked "CRITICAL" to signal their importance
- Curiosity tools are presented as natural conversation starters rather than rigid rules
- Behavioral rules use stronger language (NEVER in caps) for non-negotiable constraints
- Overall tone shifted from procedural/robotic to warm/curious while maintaining professionalism

https://claude.ai/code/session_015LRgFu3aQyospqGF28sjnU