### PR TITLE
Refactor camera preview to integrate into editor panel

### DIFF
--- a/app/(features)/interview/components/HeaderControls.tsx
+++ b/app/(features)/interview/components/HeaderControls.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import React from "react";
-import { Camera, CameraOff } from "lucide-react";
 
 interface HeaderControlsProps {
-    isCameraOn: boolean;
-    onToggleCamera: () => void;
     isCodingStarted: boolean;
     hasSubmitted: boolean;
     timeLeft: number;
@@ -21,8 +18,6 @@ interface HeaderControlsProps {
 }
 
 const HeaderControls: React.FC<HeaderControlsProps> = ({
-    isCameraOn,
-    onToggleCamera,
     isCodingStarted,
     hasSubmitted,
     timeLeft,
@@ -51,18 +46,6 @@ const HeaderControls: React.FC<HeaderControlsProps> = ({
                     </svg>
                 </button>
             )}
-            {/* Camera toggle */}
-            <button
-                onClick={onToggleCamera}
-                className="p-2.5 rounded-full transition-all duration-200 bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 cursor-pointer"
-                title={isCameraOn ? "Turn camera off" : "Turn camera on"}
-            >
-                {isCameraOn ? (
-                    <CameraOff className="w-5 h-5" />
-                ) : (
-                    <Camera className="w-5 h-5" />
-                )}
-            </button>
 
             {/* Timer Display */}
             {isCodingStarted && (

--- a/app/(features)/interview/components/InterviewIDE.tsx
+++ b/app/(features)/interview/components/InterviewIDE.tsx
@@ -20,7 +20,6 @@ import { useSession, signOut } from "next-auth/react";
 import { Menu } from "@headlessui/react";
 import EditorPanel from "./editor/EditorPanel";
 import InterviewOverlay from "./InterviewOverlay";
-import CameraPreview from "./CameraPreview";
 import HeaderControls from "./HeaderControls";
 import RightPanel from "./RightPanel";
 import CodingEvaluationDebugPanel from "./debug/CodingEvaluationDebugPanel";
@@ -1323,8 +1322,6 @@ const InterviewerContent: React.FC<InterviewerContentProps> = ({
 
                         {/* HeaderControls (Camera, Timer, Start/Submit) */}
                         <HeaderControls
-                            isCameraOn={isCameraOn}
-                            onToggleCamera={toggleCamera}
                             isCodingStarted={isCodingStarted}
                             hasSubmitted={Boolean(state.hasSubmitted)}
                             timeLeft={timeLeft}
@@ -1474,10 +1471,8 @@ const InterviewerContent: React.FC<InterviewerContentProps> = ({
                                     } catch {}
                                 }}
                                 onExecutionResult={handleExecutionResult}
-                            />
-                            <CameraPreview
                                 isCameraOn={isCameraOn}
-                                videoRef={selfVideoRef}
+                                selfVideoRef={selfVideoRef}
                             />
                         </div>
                     </Panel>

--- a/app/(features)/interview/components/editor/EditorPanel.tsx
+++ b/app/(features)/interview/components/editor/EditorPanel.tsx
@@ -73,6 +73,8 @@ interface EditorPanelProps {
         status: "success" | "error";
         output: string;
     }) => void;
+    isCameraOn?: boolean;
+    selfVideoRef?: React.RefObject<HTMLVideoElement>;
 }
 
 const EditorPanel: React.FC<EditorPanelProps> = ({
@@ -96,6 +98,8 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
     onEditorReady,
     onAskFollowup,
     onExecutionResult,
+    isCameraOn = false,
+    selfVideoRef,
 }) => {
     if (propCurrentCode === undefined) {
         throw new Error("EditorPanel requires currentCode");
@@ -481,7 +485,7 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
             </div>
 
             {/* Dynamic Content */}
-            <div className="flex-1">
+            <div className="flex-1 relative">
                 {activeTab === "editor" ? (
                     <Editor
                         height="100%"
@@ -511,6 +515,19 @@ const EditorPanel: React.FC<EditorPanelProps> = ({
                         language={language}
                         onExecutionResult={onExecutionResult}
                     />
+                )}
+
+                {/* Camera Feed in Bottom Right */}
+                {isCameraOn && selfVideoRef && (
+                    <div className="absolute bottom-4 right-4 w-64 h-48 rounded-lg overflow-hidden shadow-lg border-2 border-gray-200 dark:border-gray-700 bg-black">
+                        <video
+                            ref={selfVideoRef}
+                            className="w-full h-full object-cover [transform:scaleX(-1)]"
+                            muted
+                            playsInline
+                            autoPlay
+                        />
+                    </div>
                 )}
             </div>
         </div>


### PR DESCRIPTION
## Summary
Refactored the camera preview component to be integrated directly into the EditorPanel component instead of being a separate component. This simplifies the component hierarchy and improves the layout by positioning the camera feed in the bottom-right corner of the editor area.

## Key Changes
- **Removed CameraPreview component**: Eliminated the standalone `CameraPreview` component and its import from `InterviewIDE.tsx`
- **Removed camera controls from HeaderControls**: Deleted the camera toggle button and related props (`isCameraOn`, `onToggleCamera`) from the `HeaderControls` component
- **Integrated camera feed into EditorPanel**: 
  - Added `isCameraOn` and `selfVideoRef` props to `EditorPanel`
  - Implemented camera video element as an absolute-positioned overlay in the bottom-right corner of the editor panel
  - Applied styling with rounded corners, shadow, border, and horizontal flip transformation
- **Updated InterviewIDE**: Modified the component to pass camera-related props directly to `EditorPanel` instead of managing them separately

## Implementation Details
- Camera feed is positioned absolutely within the editor panel's dynamic content area (`flex-1 relative`)
- Video dimensions: 256px width × 192px height (w-64 h-48)
- Applied `[transform:scaleX(-1)]` to mirror the video feed for a natural self-view experience
- Camera feed only renders when `isCameraOn` is true and `selfVideoRef` is provided
- Maintains dark mode support with appropriate border colors

https://claude.ai/code/session_01BG8QNGDxkSqGYYUWBZc2t4