### PR TITLE
Add one-minute background countdown badge to interview flow

### DIFF
--- a/app/(features)/interview/page.tsx
+++ b/app/(features)/interview/page.tsx
@@ -121,6 +121,8 @@ function InterviewPageContent() {
   const companyId = useSelector((state: RootState) => state.interview.companyId);
   const currentJobId = useSelector((state: RootState) => state.interview.jobId);
   const currentJobTitle = useSelector((state: RootState) => state.interview.jobTitle);
+  const backgroundStartedAtMs = useSelector((state: RootState) => state.background.startedAtMs);
+  const backgroundTimeboxMs = useSelector((state: RootState) => state.background.timeboxMs);
   const preloadedFirstQuestion = useSelector((state: RootState) => state.interview.preloadedFirstQuestion);
   const preloadedFirstIntent = useSelector((state: RootState) => state.interview.preloadedFirstIntent);
   const userId = useSelector((state: RootState) => state.interview.userId);
@@ -154,6 +156,7 @@ function InterviewPageContent() {
   const [isUserRecording, setIsUserRecording] = useState(false);
   const [currentIntent, setCurrentIntent] = useState<string>("");
   const [pendingIntent, setPendingIntent] = useState<string>("");
+  const [backgroundNowMs, setBackgroundNowMs] = useState<number>(Date.now());
 
   const skipToCoding = process.env.NEXT_PUBLIC_SKIP_TO_CODING === "true";
   const skipScreenShare = process.env.NEXT_PUBLIC_SKIP_SCREEN_SHARE === "true";
@@ -876,6 +879,31 @@ function InterviewPageContent() {
     return () => clearInterval(interval);
   }, [stage, completed, submitting, backgroundTimeSeconds]);
 
+  useEffect(() => {
+    if (stage !== "background" || !backgroundStartedAtMs) return;
+
+    const interval = setInterval(() => {
+      setBackgroundNowMs(Date.now());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [stage, backgroundStartedAtMs]);
+
+  const effectiveBackgroundTimeboxMs = backgroundTimeboxMs || (backgroundTimeSeconds ? backgroundTimeSeconds * 1000 : 7000);
+  const backgroundElapsedMs = backgroundStartedAtMs ? Math.max(0, backgroundNowMs - backgroundStartedAtMs) : 0;
+  const backgroundRemainingMs = Math.max(0, effectiveBackgroundTimeboxMs - backgroundElapsedMs);
+  const shouldShowBackgroundCountdown =
+    stage === "background" &&
+    Boolean(backgroundStartedAtMs) &&
+    !completed &&
+    backgroundRemainingMs > 0 &&
+    backgroundRemainingMs <= 60000;
+  const isUrgentCountdown = backgroundRemainingMs <= 10000;
+  const backgroundRemainingSeconds = Math.ceil(backgroundRemainingMs / 1000);
+  const backgroundMinutes = Math.floor(backgroundRemainingSeconds / 60);
+  const backgroundSeconds = backgroundRemainingSeconds % 60;
+  const backgroundCountdownLabel = `${backgroundMinutes}:${String(backgroundSeconds).padStart(2, "0")}`;
+
   // Start coding handler
   const handleStartCoding = () => {
     if (!companyId || !currentJobId) {
@@ -1352,6 +1380,22 @@ function InterviewPageContent() {
       {!isPreloading && stage !== "coding" && (
         <div className="pt-8 px-6">
           <Breadcrumbs items={breadcrumbTrail} />
+        </div>
+      )}
+
+      {shouldShowBackgroundCountdown && (
+        <div className="absolute top-6 right-6 z-30 pointer-events-none">
+          <div
+            className={`rounded-full border px-3 py-1.5 text-sm font-semibold font-mono shadow-sm backdrop-blur-sm transition-colors duration-300 ${
+              isUrgentCountdown
+                ? "bg-red-50/90 border-red-200 text-red-700"
+                : "bg-violet-50/90 border-violet-200 text-violet-700"
+            }`}
+            aria-live="polite"
+            role="status"
+          >
+            {backgroundCountdownLabel}
+          </div>
         </div>
       )}
       


### PR DESCRIPTION
### Motivation
- Provide candidates a subtle, non-intrusive cue during the background question phase so they are prepared when the hidden timer is about to end. 
- Follow the UI guidance (sfinx-ui-designer) to make the badge visually consistent and escalate styling in the final 10 seconds. 

### Description
- Read background timer state from Redux (`background.startedAtMs`, `background.timeboxMs`) and add a local 1s ticker to compute live remaining time in `app/(features)/interview/page.tsx`. 
- Show a floating, non-interactive countdown badge in the top-right when the remaining time is <= 60s, and apply an urgent red treatment when <= 10s. 
- Compute formatted minutes:seconds label and ensure the badge is hidden outside the last minute and after completion. 
- Kept the implementation fully typed and scoped to the interview page so it does not affect other flows. 

### Testing
- Ran `pnpm -s exec eslint 'app/(features)/interview/page.tsx'` which passed for the modified file. 
- Ran `pnpm -s exec tsc --noEmit` which failed due to pre-existing, repository-wide TypeScript issues unrelated to this change. 
- Launched the app with `pnpm dev` and captured a browser screenshot of the interview page to validate visual placement and color transitions (artifact produced during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae08a8f298832bb5405ff5ffc5aa67)