### PR TITLE
Discard unsubmitted interview sessions

### DIFF
--- a/app/(features)/interview/page.tsx
+++ b/app/(features)/interview/page.tsx
@@ -170,7 +170,6 @@ function InterviewPageContent() {
   const clickSoundRef = useRef<HTMLAudioElement | null>(null);
   const startSoundRef = useRef<HTMLAudioElement | null>(null);
   const interviewSessionIdRef = useRef<string | null>(null);
-  const completedRef = useRef<boolean>(false);
   const hasAutoStartedRef = useRef<boolean>(false);
   const hasPreloadedRef = useRef<boolean>(false);
   const skipToCodingStartAttemptedRef = useRef<boolean>(false);
@@ -280,16 +279,7 @@ function InterviewPageContent() {
     interviewSessionIdRef.current = interviewSessionId;
   }, [interviewSessionId]);
 
-  useEffect(() => {
-    completedRef.current = completed;
-  }, [completed]);
 
-  // Monitor stage for completion
-  useEffect(() => {
-    if (stage === "coding") {
-      setCompleted(true);
-    }
-  }, [stage]);
 
   // Cleanup mic on unmount
   useEffect(() => {
@@ -306,10 +296,8 @@ function InterviewPageContent() {
     // Only run cleanup on actual unmount, not on dependency changes
     return () => {
       const sessionId = interviewSessionIdRef.current;
-      const isCompleted = completedRef.current;
-
-      if (!sessionId || isCompleted) {
-        log.info(LOG_CATEGORY, "[interview] Skipping cleanup - sessionId:", sessionId, "completed:", isCompleted);
+      if (!sessionId) {
+        log.info(LOG_CATEGORY, "[interview] Skipping cleanup - no sessionId");
         return;
       }
 
@@ -327,7 +315,7 @@ function InterviewPageContent() {
         micStream.getTracks().forEach((track) => track.stop());
       }
 
-      // Mark session as abandoned in backend
+      // Terminate session in backend (deletes if unsubmitted)
       const url = `/api/interviews/session/${sessionId}/terminate`;
 
       // Use fetch without await (fire and forget on unmount)
@@ -344,7 +332,7 @@ function InterviewPageContent() {
   // Cleanup on page close/refresh
   useEffect(() => {
     const handleBeforeUnload = () => {
-      if (!interviewSessionId || completed) return;
+      if (!interviewSessionId) return;
 
       log.info(LOG_CATEGORY, "[interview] Page closing - terminating session");
 

--- a/app/api/company/applicants/route.ts
+++ b/app/api/company/applicants/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from "next-auth";
 import { authOptions, prisma, getCached, setCached } from "app/shared/services/server";
 import { extractTopHighlights } from "../jobs/highlightUtils";
 
+const SUBMITTED_SESSION_STATUSES = ["PROCESSING", "COMPLETED"] as const;
+
 /**
  * GET /api/company/applicants
  * Returns ALL applicants across ALL company jobs with scores, highlights, and job info.
@@ -47,6 +49,11 @@ export async function GET() {
                   },
                 },
                 interviewSessions: {
+                  where: {
+                    status: {
+                      in: [...SUBMITTED_SESSION_STATUSES],
+                    },
+                  },
                   select: {
                     id: true,
                     finalScore: true,
@@ -91,7 +98,7 @@ export async function GET() {
             matchScore: latestSession?.finalScore ?? null,
             sessionStatus: latestSession?.status ?? null,
             highlights: extractTopHighlights(latestSession),
-            interviewCompleted: !!latestSession,
+            interviewCompleted: latestSession?.status === "COMPLETED",
             applicationId: app.id,
             jobId: job.id,
             jobTitle: job.title,

--- a/app/api/company/jobs/[jobId]/applicants/route.ts
+++ b/app/api/company/jobs/[jobId]/applicants/route.ts
@@ -4,6 +4,8 @@ import { authOptions, getCached, setCached } from "app/shared/services/server";
 import prisma from "lib/prisma";
 import { extractTopHighlights } from "../../highlightUtils";
 
+const SUBMITTED_SESSION_STATUSES = ["PROCESSING", "COMPLETED"] as const;
+
 /**
  * GET /api/company/jobs/[jobId]/applicants
  * Fetch all applicants for a specific job.
@@ -84,9 +86,15 @@ export async function GET(
           },
         },
         interviewSessions: {
+          where: {
+            status: {
+              in: [...SUBMITTED_SESSION_STATUSES],
+            },
+          },
           select: {
             id: true,
             finalScore: true,
+            status: true,
             createdAt: true,
             telemetryData: {
               include: {
@@ -120,7 +128,7 @@ export async function GET(
           image: app.candidate.image,
           matchScore,
           appliedAt: app.appliedAt.toISOString(),
-          interviewCompleted: !!latestSession,
+          interviewCompleted: latestSession?.status === "COMPLETED",
           applicationId: app.id,
           highlights,
         };

--- a/app/api/company/jobs/with-applicants/route.ts
+++ b/app/api/company/jobs/with-applicants/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions, prisma, getCached, setCached } from "app/shared/services/server";
 
+const SUBMITTED_SESSION_STATUSES = ["PROCESSING", "COMPLETED"] as const;
+
 export async function GET() {
     const session = await getServerSession(authOptions);
     if (!session?.user || (session.user as any).role !== "COMPANY") {
@@ -34,6 +36,11 @@ export async function GET() {
                     applications: {
                         include: {
                             interviewSessions: {
+                                where: {
+                                    status: {
+                                        in: [...SUBMITTED_SESSION_STATUSES],
+                                    },
+                                },
                                 select: {
                                     id: true,
                                     finalScore: true,

--- a/app/api/interviews/session/[sessionId]/terminate/route.ts
+++ b/app/api/interviews/session/[sessionId]/terminate/route.ts
@@ -19,8 +19,8 @@ function normalizeSessionId(sessionId: string | string[] | undefined) {
 }
 
 /**
- * Terminate an interview session (mark as abandoned).
- * Used when user leaves the interview page.
+ * Terminate an interview session.
+ * Unsubmitted sessions are deleted so they are not visible to companies.
  */
 export async function POST(request: NextRequest, context: RouteContext) {
     try {
@@ -69,22 +69,30 @@ export async function POST(request: NextRequest, context: RouteContext) {
             );
         }
 
-        // Mark session as abandoned
-        const updatedSession = await prisma.interviewSession.update({
+        if (interviewSession.status === "PROCESSING" || interviewSession.status === "COMPLETED") {
+            log.info(
+                LOG_CATEGORY,
+                "[Session TERMINATE] ℹ️ Keeping submitted session:",
+                interviewSession.id,
+                "status:",
+                interviewSession.status
+            );
+            return NextResponse.json({
+                message: "Interview session already submitted; preserved",
+                interviewSession,
+            });
+        }
+
+        await prisma.interviewSession.delete({
             where: {
                 id: sessionId,
             },
-            data: {
-                status: "ABANDONED",
-                completedAt: new Date(),
-            },
         });
 
-        log.info(LOG_CATEGORY, "[Session TERMINATE] ✅ Session marked as abandoned:", updatedSession.id);
+        log.info(LOG_CATEGORY, "[Session TERMINATE] ✅ Unsubmitted session deleted:", sessionId);
 
         return NextResponse.json({
-            message: "Interview session terminated",
-            interviewSession: updatedSession,
+            message: "Interview session discarded",
         });
     } catch (error) {
         log.error(LOG_CATEGORY, "[Session TERMINATE] ❌ ERROR:", error);


### PR DESCRIPTION
### Motivation
- Prevent incomplete interview sessions from appearing to companies by removing any session that was never submitted (only submitted sessions should be visible).
- Simplify client-side cleanup so the backend is the source of truth for whether a session is preserved or discarded.

### Description
- Change terminate API to delete unsubmitted sessions and preserve submitted sessions with statuses `PROCESSING` or `COMPLETED` (`app/api/interviews/session/[sessionId]/terminate/route.ts`).
- Update company-facing applicant endpoints to only load/interrogate sessions whose status is in `['PROCESSING','COMPLETED']` and mark `interviewCompleted` only when status is `COMPLETED` (`app/api/company/applicants/route.ts`, `app/api/company/jobs/[jobId]/applicants/route.ts`, `app/api/company/jobs/with-applicants/route.ts`).
- Remove local skip-on-completed logic and ensure the interview page always calls terminate on unmount / page close when a session id exists (`app/(features)/interview/page.tsx`).
- Add a shared `SUBMITTED_SESSION_STATUSES` constant where needed and include `status` where necessary for correct client/server logic.

### Testing
- Ran the project linter: `pnpm -s next lint --file 'app/api/interviews/session/[sessionId]/terminate/route.ts' --file 'app/api/company/applicants/route.ts' --file 'app/api/company/jobs/[jobId]/applicants/route.ts' --file 'app/api/company/jobs/with-applicants/route.ts' --file 'app/(features)/interview/page.tsx'`, which completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae093cc080832ba418dd00e3d3edce)